### PR TITLE
:bug: Fix CI merge_ok step to check matrix results properly

### DIFF
--- a/ci/.github/workflows/unit_tests.yml
+++ b/ci/.github/workflows/unit_tests.yml
@@ -213,6 +213,13 @@ jobs:
   merge_ok:
     runs-on: ubuntu-22.04
     needs: [build_and_test, quality_checks_pass, sanitize, valgrind]
+    if: ${{ always() }}
     steps:
       - name: Enable merge
-        run: echo "OK to merge!"
+        if: >-
+          ${{
+               contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+            || contains(needs.*.result, 'skipped')
+          }}
+        run: exit 1


### PR DESCRIPTION
There have been several occasions when CIB merges happened despite failing builds - I think this is the reason.

See https://github.com/orgs/community/discussions/26822