### PR TITLE
:sparkles: Add match library to clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,7 +5,7 @@ IncludeBlocks: Regroup
 IncludeCategories:
   - Regex: '^".*'
     Priority: 1
-  - Regex: '^<(async|conc|container|cib|flow|interrupt|log|lookup|msg|safe|sc|seq)/.*'
+  - Regex: '^<(async|conc|container|cib|flow|interrupt|log|lookup|match|msg|safe|sc|seq)/.*'
     Priority: 4
   - Regex: '^<stdx/.*'
     Priority: 8


### PR DESCRIPTION
In preparation for separating the match library in cib.