### PR TITLE
:construction_worker: Remove clang-14-libstdc++ from build matrix

### DIFF
--- a/ci/.github/workflows/unit_tests.yml
+++ b/ci/.github/workflows/unit_tests.yml
@@ -95,6 +95,9 @@ jobs:
           - compiler: gcc
             version: 14
           - compiler: clang
+            version: 14
+            stdlib: libstdc++
+          - compiler: clang
             version: 13
           - compiler: clang
             version: 12


### PR DESCRIPTION
There is a bug in clang-14 consteval handling which interacts poorly with libstdc++.

It manifests with the error: `call to consteval function 'std::chrono::hh_mm_ss::_S_fractional_width' is not a constant expression` when compiling anything including `<chrono>`.