### PR TITLE
:construction_worker: Add cmake options to control what gets installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,15 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS
     ON
     CACHE BOOL "Export compile commands to compile_commands.json." FORCE)
 
+option(INFRA_PROVIDE_GITHUB_WORKFLOWS
+       "Provide unit_test and documentation workflows" ON)
+option(INFRA_PROVIDE_CLANG_FORMAT "Provide .clang-format file" ON)
+option(INFRA_PROVIDE_CLANG_TIDY "Provide .clang-tidy file" ON)
+option(INFRA_PROVIDE_CMAKE_FORMAT "Provide .cmake-format.yaml file" ON)
+option(INFRA_PROVIDE_PRESETS "Provide cmake presets and toolchains" ON)
+option(INFRA_PROVIDE_GITIGNORE "Add provided things to .gitignore" ON)
+option(INFRA_USE_SYMLINKS "Use symlinks to provide common files" ON)
+
 include(cmake/cpm_recipes.cmake)
 include(cmake/dependencies.cmake)
 include(cmake/libraries.cmake)

--- a/test/application/clean.sh
+++ b/test/application/clean.sh
@@ -2,12 +2,12 @@
 
 set -euo pipefail
 
-rm .clang-format
-rm .clang-tidy
-rm .cmake-format.yaml
-rm .gitignore
-rm CMakePresets.json
-rm toolchains
+rm -f .clang-format
+rm -f .clang-tidy
+rm -f .cmake-format.yaml
+rm -f .gitignore
+rm -f CMakePresets.json
+rm -f toolchains
 
 rm -rf build
 rm -rf .github

--- a/test/library/clean.sh
+++ b/test/library/clean.sh
@@ -2,12 +2,12 @@
 
 set -euo pipefail
 
-rm .clang-format
-rm .clang-tidy
-rm .cmake-format.yaml
-rm .gitignore
-rm CMakePresets.json
-rm toolchains
+rm -f .clang-format
+rm -f .clang-tidy
+rm -f .cmake-format.yaml
+rm -f .gitignore
+rm -f CMakePresets.json
+rm -f toolchains
 
 rm -rf build
 rm -rf .github


### PR DESCRIPTION
Projects that use this repo should be able to choose what they want, with cmake options:
 - `INFRA_PROVIDE_GITHUB_WORKFLOWS` (`.github` directory contents)
 - `INFRA_PROVIDE_CLANG_FORMAT` (`.clang-format` file)
 - `INFRA_PROVIDE_CLANG_TIDY` (`.clang-tidy` file)
 - `INFRA_PROVIDE_CMAKE_FORMAT` (`.cmake_format.yaml` file)
 - `INFRA_PROVIDE_PRESETS` (`CMakePresets.json` file and `toolchains` directory)
 - `INFRA_PROVIDE_GITIGNORE` (`.gitignore` file)

And
 - `INFRA_USE_SYMLINKS` Which will copy files if set to OFF.

All the options default to ON which is the existing behaviour. The `.gitignore` file reflects only what is provided and only if `INFRA_PROVIDE_SYMLINKS` is ON.