### PR TITLE
:construction_worker: Add fuzz testing

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,7 +11,7 @@ IncludeCategories:
     Priority: 4
   - Regex: '^<stdx/.*'
     Priority: 8
-  - Regex: '^<(boost|catch2|fmt|gmock|gtest|rapidcheck)/.*'
+  - Regex: '^<(boost|catch2|fmt|fuzztest|gmock|gtest|rapidcheck)/.*'
     Priority: 9
   - Regex: '^<GUnit.h>'
     Priority: 9

--- a/docs/testing.adoc
+++ b/docs/testing.adoc
@@ -26,6 +26,22 @@ property-based testing; it integrates with either Catch2 or GoogleTest (or
 GUnit, which is based on GoogleTest). See the RapidCheck documentation for how
 to use it with either of those frameworks.
 
+=== Fuzz tests
+
+[source,cmake]
+----
+add_fuzz_test(
+  my_test
+  FILES my_test.cpp
+  LIBRARIES my_lib)
+----
+
+`add_fuzz_test` is a basic function for defining tests that use Google's
+https://github.com/google/fuzztest[`fuzztest`]. `GTEST` and `rapidcheck` macros
+are also available with these tests.
+
+NOTE: Fuzz tests are enabled only when the compiler is Clang.
+
 === BDD feature tests
 
 GUnit also provides for BDD-style "feature tests", which define tests in a

--- a/test/application/test/CMakeLists.txt
+++ b/test/application/test/CMakeLists.txt
@@ -14,5 +14,7 @@ add_feature_test(
     LIBRARIES
     warnings)
 
+add_fuzz_test(fuzz_test FILES fuzz_test.cpp LIBRARIES warnings)
+
 add_compile_fail_test(compile_fail_test.cpp LIBRARIES warnings)
 add_compile_fail_test(compile_fail_test_no_pattern.cpp LIBRARIES warnings)

--- a/test/application/test/fuzz_test.cpp
+++ b/test/application/test/fuzz_test.cpp
@@ -1,0 +1,10 @@
+#include <fuzztest/fuzztest.h>
+#include <gtest/gtest.h>
+
+namespace {
+void integer_addition_commutes(unsigned int a, unsigned int b) {
+    EXPECT_EQ(a + b, b + a);
+}
+} // namespace
+
+FUZZ_TEST(tests, integer_addition_commutes);


### PR DESCRIPTION
Tests can now be created with `add_fuzz_test`, using Google's `fuzztest` library. https://github.com/google/fuzztest