### PR TITLE
:construction_worker: Add NORANDOM flag for tests to opt out

### DIFF
--- a/test/application/test/CMakeLists.txt
+++ b/test/application/test/CMakeLists.txt
@@ -18,3 +18,12 @@ add_fuzz_test(fuzz_test FILES fuzz_test.cpp LIBRARIES warnings)
 
 add_compile_fail_test(compile_fail_test.cpp LIBRARIES warnings)
 add_compile_fail_test(compile_fail_test_no_pattern.cpp LIBRARIES warnings)
+
+add_unit_test(
+    nonrandom_test
+    CATCH2
+    NORANDOM
+    FILES
+    nonrandom_test.cpp
+    LIBRARIES
+    warnings)

--- a/test/application/test/nonrandom_test.cpp
+++ b/test/application/test/nonrandom_test.cpp
@@ -1,0 +1,10 @@
+#include <catch2/catch_test_macros.hpp>
+#include <rapidcheck/catch.h>
+
+namespace {
+bool run_order{};
+}
+
+TEST_CASE("nonrandom test part 1", "[nonrandom_test]") { run_order = true; }
+
+TEST_CASE("nonrandom test part 2", "[nonrandom_test]") { CHECK(run_order); }


### PR DESCRIPTION
Opting out of randomized testing is not a good practice, so you get a CMake warning. But this allows a reasonable migration to best practices.