### PR TITLE
:adhesive_bandage: Silence GUnit vtable UB

### DIFF
--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -162,6 +162,7 @@ function(add_unit_test_target name)
             rapidcheck
             rapidcheck_gtest
             rapidcheck_gmock)
+        target_compile_options(${name} PRIVATE "-fno-sanitize=vptr")
         if(UNIT_NORANDOM)
             message(
                 WARNING


### PR DESCRIPTION
Problem:
 - GUnit mocking code provokes an error from UBSan: "runtime error: member call on address &lt;addr&gt; which does not point to an object of type &lt;type&gt;; note: object has invalid vptr"

Solution:
 - Disable UBSan vptr checks for GUnit tests.

Note:
 - After discussion with @krzysztof-jusiak this seems the most expedient approach.