### PR TITLE
:construction_worker: Turn on sanitizers for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,10 +42,10 @@ jobs:
           sudo apt update && sudo apt install -y asciidoctor
           sudo gem install asciidoctor asciidoctor-diagram rouge
 
-      - name: Install cmake and cmake-format
+      - name: Install cmake-format
         run: |
           sudo pip3 install --upgrade pip
-          sudo pip3 install cmake pyyaml cmake-format
+          sudo pip3 install pyyaml cmake-format
           echo "${HOME}/.local/bin" >> $GITHUB_PATH
 
       - name: Checkout target branch
@@ -92,3 +92,30 @@ jobs:
       - name: Verify app setup
         working-directory: ${{github.workspace}}/test
         run: ./verify_links.sh
+
+  sanitize:
+    runs-on: ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [undefined, address]
+
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Install build tools
+        run: |
+          wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh ${{env.TARGET_LLVM_VERSION}}
+          sudo apt install -y python3-pip ninja-build clang-tidy-${{env.TARGET_LLVM_VERSION}} clang-format-${{env.TARGET_LLVM_VERSION}}
+
+      - name: Configure cmake for app
+        env:
+          CC: "/usr/lib/llvm-${{env.TARGET_LLVM_VERSION}}/bin/clang"
+          CXX: "/usr/lib/llvm-${{env.TARGET_LLVM_VERSION}}/bin/clang++"
+          SANITIZERS: ${{matrix.sanitizer}}
+        working-directory: ${{github.workspace}}/test/application
+        run: cmake -Bbuild
+
+      - name: Build app and run tests
+        working-directory: ${{github.workspace}}/test/application
+        run: cmake --build build -t unit_tests

--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -18,6 +18,9 @@ set(MEMORYCHECK_COMMAND_OPTIONS
 configure_file(${CMAKE_ROOT}/Modules/DartConfiguration.tcl.in
                ${PROJECT_BINARY_DIR}/DartConfiguration.tcl)
 
+add_library(sanitizer-exceptions INTERFACE)
+target_compile_options(sanitizer-exceptions INTERFACE -fno-sanitize=vptr)
+
 macro(get_catch2)
     if(NOT TARGET Catch2::Catch2WithMain)
         add_versioned_package("gh:catchorg/Catch2@3.5.0")
@@ -162,7 +165,7 @@ function(add_unit_test_target name)
             rapidcheck
             rapidcheck_gtest
             rapidcheck_gmock)
-        target_compile_options(${name} PRIVATE "-fno-sanitize=vptr")
+        target_link_libraries(${name} PRIVATE sanitizer-exceptions)
         if(UNIT_NORANDOM)
             message(
                 WARNING


### PR DESCRIPTION
Problem:
 - Tests for this repo run without sanitizers in CI, which means the test dependencies could introduce problems.

Solution:
 - Add sanitizer jobs with UBSan and ASan.