### PR TITLE
:art: Allow a later hash to supersede an asked-for version dependency

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -73,7 +73,7 @@ function(check_dependency_version dep version)
         endif()
 
         identify_git_tag(${dep} ${version} is_tag)
-        if(is_tag)
+        if(is_tag AND head_version)
             check_version(${dep} ${version} ${comp} ${head_version})
         else()
             execute_process(


### PR DESCRIPTION
Problem:
- Ask for dependency A at git hash H
- Later ask for dependency A at git tag T
- This fails even when the hash pointed to by T is an ancestor of H

Solution:
- If no tag points at the current head, fall back to ancestry checking