### PR TITLE
:white_check_mark: Add CPM recipe tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,6 +94,11 @@ jobs:
           cmake --build build -t build_unit_tests
           ctest --test-dir build
 
+      - name: Run recipe tests
+        working-directory: ${{github.workspace}}/test/application
+        run: |
+          cmake --build build -t recipe_tests
+
       - name: Check app quality
         working-directory: ${{github.workspace}}/test/application
         run: cmake --build build -t ci-quality

--- a/cmake/cpm_recipes.cmake
+++ b/cmake/cpm_recipes.cmake
@@ -45,32 +45,3 @@ if(NOT COMMAND boost_sml_recipe)
             "SML_BUILD_TESTS OFF")
     endmacro()
 endif()
-
-if(NOT COMMAND mp_units_recipe)
-    macro(mp_units_recipe VERSION)
-        add_versioned_package("gh:gsl-lite/gsl-lite@0.40.0")
-        set(gsl-lite_DIR "${gsl-lite_BINARY_DIR}")
-
-        add_versioned_package(
-            NAME
-            fmt
-            GITHUB_REPOSITORY
-            "fmtlib/fmt"
-            GIT_TAG
-            9.1.0
-            OPTIONS
-            "FMT_INSTALL ON")
-        set(fmt_DIR "${fmt_BINARY_DIR}")
-
-        add_versioned_package(
-            NAME
-            mp-units
-            GITHUB_REPOSITORY
-            "mpusz/units"
-            GIT_TAG
-            ${VERSION}
-            DOWNLOAD_ONLY
-            YES)
-        add_subdirectory("${mp-units_SOURCE_DIR}/src")
-    endmacro()
-endif()

--- a/test/application/CMakeLists.txt
+++ b/test/application/CMakeLists.txt
@@ -5,13 +5,13 @@ include(cmake/get_cpm.cmake)
 cpmaddpackage(NAME infra SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." GIT_TAG
               HEAD)
 
-fmt_recipe(10.2.1)
 add_versioned_package(NAME test_lib SOURCE_DIR
                       "${CMAKE_CURRENT_SOURCE_DIR}/../library" GIT_TAG HEAD)
 
 add_executable(test_app src/test.cpp)
-target_link_libraries(test_app PRIVATE test_lib fmt::fmt-header-only)
+target_link_libraries(test_app PRIVATE test_lib)
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     add_subdirectory(test)
+    add_subdirectory(recipes)
 endif()

--- a/test/application/recipes/CMakeLists.txt
+++ b/test/application/recipes/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_custom_target(recipe_tests)
+
+function(test_recipe NAME VERSION LIBNAME)
+    cmake_language(CALL ${NAME}_recipe ${VERSION})
+    add_executable(${NAME}_recipe_app ${NAME}_recipe.cpp)
+    target_link_libraries(${NAME}_recipe_app PRIVATE ${LIBNAME})
+    add_dependencies(recipe_tests ${NAME}_recipe_app)
+endfunction()
+
+test_recipe(fmt "10.2.1" fmt::fmt-header-only)
+test_recipe(boost_sml "v1.1.11" sml)
+test_recipe(boost_hana "boost-1.83.0" boost_hana)

--- a/test/application/recipes/boost_hana_recipe.cpp
+++ b/test/application/recipes/boost_hana_recipe.cpp
@@ -1,0 +1,3 @@
+#include <boost/hana.hpp>
+
+auto main() -> int {}

--- a/test/application/recipes/boost_sml_recipe.cpp
+++ b/test/application/recipes/boost_sml_recipe.cpp
@@ -1,0 +1,3 @@
+#include <boost/sml.hpp>
+
+auto main() -> int {}

--- a/test/application/recipes/fmt_recipe.cpp
+++ b/test/application/recipes/fmt_recipe.cpp
@@ -1,0 +1,3 @@
+#include <fmt/format.h>
+
+auto main() -> int {}

--- a/test/application/src/test.cpp
+++ b/test/application/src/test.cpp
@@ -1,5 +1,3 @@
-#include <fmt/format.h>
-
 #include <test_lib/test.hpp>
 
 auto main() -> int {}


### PR DESCRIPTION
Removed mpunits recipe because it was unused, and clashing with the fmtlib recipe.