### PR TITLE
:construction_worker: Update self when out of date

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,57 +4,93 @@ if(NOT PROJECT_NAME)
     project(cicd)
 endif()
 
-if(PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
-    file(REMOVE "${PROJECT_SOURCE_DIR}/cpm-package-lock.cmake")
-    file(REMOVE_RECURSE "${PROJECT_SOURCE_DIR}/_deps")
-    file(REMOVE_RECURSE "${PROJECT_SOURCE_DIR}/CPM_modules")
-    message(
-        FATAL_ERROR
-            "In-source builds are a bad idea. Please make a build directory instead. "
-            "You should now remove the leftover files: CMakeCache.txt and CMakeFiles/."
-    )
-endif()
-
-if(NOT DEFINED CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD
-        20
-        CACHE INTERNAL "" FORCE)
-endif()
-
-set(CMAKE_EXPORT_COMPILE_COMMANDS
-    ON
-    CACHE BOOL "Export compile commands to compile_commands.json." FORCE)
-
-option(INFRA_PROVIDE_GITHUB_WORKFLOWS
-       "Provide unit_test and documentation workflows" ON)
-option(INFRA_PROVIDE_CLANG_FORMAT "Provide .clang-format file" ON)
-option(INFRA_PROVIDE_CLANG_TIDY "Provide .clang-tidy file" ON)
-option(INFRA_PROVIDE_CMAKE_FORMAT "Provide .cmake-format.yaml file" ON)
-option(INFRA_PROVIDE_PRESETS "Provide cmake presets and toolchains" ON)
-option(INFRA_PROVIDE_GITIGNORE "Add provided things to .gitignore" ON)
-option(INFRA_USE_SYMLINKS "Use symlinks to provide common files" ON)
-
-if(PROJECT_SOURCE_DIR STREQUAL CMAKE_CURRENT_LIST_DIR)
-    set(INFRA_PROVIDE_GITHUB_WORKFLOWS OFF)
-    set(INFRA_PROVIDE_CLANG_FORMAT OFF)
-    set(INFRA_PROVIDE_CLANG_TIDY OFF)
-    set(INFRA_PROVIDE_CMAKE_FORMAT OFF)
-    set(INFRA_PROVIDE_PRESETS OFF)
-    set(INFRA_PROVIDE_GITIGNORE OFF)
-endif()
-
 find_program(GIT_PROGRAM "git")
 if(NOT GIT_PROGRAM)
     message(FATAL_ERROR "git not found!")
 endif()
 
-include(cmake/cpm_recipes.cmake)
-include(cmake/dependencies.cmake)
-include(cmake/libraries.cmake)
-include(cmake/setup.cmake)
-include(cmake/quality.cmake)
-include(cmake/docs.cmake)
+function(cicd_check_self_update)
+    # trivial early-out if:
+    if(NOT DEFINED CPM_ARGS_NAME) # not being CPM-included
+        return()
+    endif()
+    if(NOT DEFINED CPM_ARGS_GIT_REPOSITORY) # working with local copy
+        return()
+    endif()
+    if(DEFINED ${CPM_ARGS_NAME}_ADDED) # already fetched
+        return()
+    endif()
+    if(NOT DEFINED ${CPM_ARGS_NAME}_SOURCE_DIR) # no source directory?
+        return()
+    endif()
 
-if(PROJECT_SOURCE_DIR STREQUAL CMAKE_CURRENT_LIST_DIR)
-    add_docs(docs)
+    # only update if we're actually processing this repo
+    file(REAL_PATH ${${CPM_ARGS_NAME}_SOURCE_DIR} my_path)
+    if(NOT CMAKE_CURRENT_LIST_DIR STREQUAL my_path)
+        return()
+    endif()
+
+    # if you asked for the actual hash I'm already at, we're good: this is the
+    # case whenever you pin to a hash
+    execute_process(
+        COMMAND ${GIT_PROGRAM} rev-parse HEAD
+        WORKING_DIRECTORY ${my_path}
+        OUTPUT_VARIABLE head_hash
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(head_hash STREQUAL ${CPM_ARGS_GIT_TAG})
+        return()
+    endif()
+
+    message(
+        STATUS
+            "CICD: cached version (${head_hash}) is not requested version (${CPM_ARGS_GIT_TAG}); checking upstream"
+    )
+
+    # what's the hash for what you asked for?
+    execute_process(
+        COMMAND ${GIT_PROGRAM} ls-remote -h ${CPM_ARGS_GIT_REPOSITORY}
+                ${CPM_ARGS_GIT_TAG}
+        WORKING_DIRECTORY ${my_path}
+        OUTPUT_VARIABLE remote_hash
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+    string(REGEX REPLACE "\t.*" "" remote_hash ${remote_hash})
+    message(STATUS "CICD: requested version hash is ${remote_hash}")
+
+    # do we already fulfil that hash?
+    execute_process(
+        COMMAND ${GIT_PROGRAM} merge-base --is-ancestor ${remote_hash}
+                ${head_hash}
+        WORKING_DIRECTORY ${my_path}
+        RESULT_VARIABLE hash_ok
+        ERROR_QUIET)
+    if(hash_ok EQUAL 0)
+        message(
+            STATUS
+                "CICD: cached version (${head_hash}) fulfils requested version hash (${remote_hash})"
+        )
+    else()
+        message(
+            STATUS
+                "CICD: cached version (${head_hash}) out of date; fetching (${remote_hash})"
+        )
+        execute_process(COMMAND ${GIT_PROGRAM} fetch ${CPM_ARGS_GIT_REPOSITORY}
+                                ${remote_hash} WORKING_DIRECTORY ${my_path})
+        execute_process(
+            COMMAND ${GIT_PROGRAM} reset --hard ${remote_hash}
+            WORKING_DIRECTORY ${my_path}
+            RESULT_VARIABLE reset_ok)
+        if(NOT reset_ok EQUAL 0)
+            message(
+                FATAL
+                "CICD: Couldn't update to ${remote_hash} - check the repository at ${my_path}."
+            )
+        endif()
+        message(STATUS "CICD: cached version is now at ${remote_hash}")
+    endif()
+endfunction()
+
+option(INFRA_SELF_UPDATE "Check and update CICD repository automatically" ON)
+if(INFRA_SELF_UPDATE)
+    cicd_check_self_update()
 endif()
+include(cmake/main.cmake)

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -5,10 +5,12 @@ endif()
 include(${CMAKE_CURRENT_LIST_DIR}/get_cpm.cmake)
 
 if(NOT DEFINED ENV{CPM_SOURCE_CACHE})
-    message(
-        STATUS
-            "The environment variable \$CPM_SOURCE_CACHE is not defined: defining a CPM cache is recommended to avoid extra downloads."
-    )
+    if(NOT DEFINED CPM_SOURCE_CACHE)
+        message(
+            STATUS
+                "The environment variable \$CPM_SOURCE_CACHE is not defined: defining a CPM cache is recommended to avoid extra downloads."
+        )
+    endif()
 endif()
 
 function(check_version dep required comp)

--- a/cmake/docs.cmake
+++ b/cmake/docs.cmake
@@ -32,31 +32,34 @@ else()
 endif()
 
 function(add_docs DIRECTORY)
+    file(REAL_PATH ${DIRECTORY} real_dir)
+    file(RELATIVE_PATH rel_dir ${CMAKE_SOURCE_DIR} ${real_dir})
+    string(REPLACE "/" "_" target ${rel_dir})
     add_custom_target(
-        docs_${DIRECTORY} DEPENDS ${CMAKE_BINARY_DIR}/${DIRECTORY}/index.html
-                                  ${CMAKE_BINARY_DIR}/${DIRECTORY}/static)
-    if(EXISTS ${CMAKE_SOURCE_DIR}/${DIRECTORY}/static)
+        docs_${target} DEPENDS ${CMAKE_BINARY_DIR}/${rel_dir}/index.html
+                               ${CMAKE_BINARY_DIR}/${rel_dir}/static)
+    if(EXISTS ${CMAKE_SOURCE_DIR}/${rel_dir}/static)
         add_custom_command(
-            OUTPUT ${CMAKE_BINARY_DIR}/${DIRECTORY}/static
+            OUTPUT ${CMAKE_BINARY_DIR}/${rel_dir}/static
             COMMAND
                 ${CMAKE_COMMAND} -E copy_directory
-                ${CMAKE_SOURCE_DIR}/${DIRECTORY}/static
-                ${CMAKE_BINARY_DIR}/${DIRECTORY}/static
-            DEPENDS ${CMAKE_SOURCE_DIR}/${DIRECTORY}/static)
+                ${CMAKE_SOURCE_DIR}/${rel_dir}/static
+                ${CMAKE_BINARY_DIR}/${rel_dir}/static
+            DEPENDS ${CMAKE_SOURCE_DIR}/${rel_dir}/static)
     else()
         add_custom_command(
-            OUTPUT ${CMAKE_BINARY_DIR}/${DIRECTORY}/static
+            OUTPUT ${CMAKE_BINARY_DIR}/${rel_dir}/static
             COMMAND ${CMAKE_COMMAND} -E make_directory
-                    ${CMAKE_BINARY_DIR}/${DIRECTORY}/static)
+                    ${CMAKE_BINARY_DIR}/${rel_dir}/static)
     endif()
 
-    file(GLOB_RECURSE doc_files ${CMAKE_SOURCE_DIR}/${DIRECTORY}/*.adoc)
+    file(GLOB_RECURSE doc_files ${CMAKE_SOURCE_DIR}/${rel_dir}/*.adoc)
     add_custom_command(
-        OUTPUT ${CMAKE_BINARY_DIR}/${DIRECTORY}/index.html
+        OUTPUT ${CMAKE_BINARY_DIR}/${rel_dir}/index.html
         COMMAND
             ${ASCIIDOCTOR_PROGRAM} -r asciidoctor-diagram
-            ${CMAKE_SOURCE_DIR}/${DIRECTORY}/index.adoc -D
-            ${CMAKE_BINARY_DIR}/${DIRECTORY}
+            ${CMAKE_SOURCE_DIR}/${rel_dir}/index.adoc -D
+            ${CMAKE_BINARY_DIR}/${rel_dir}
         DEPENDS ${doc_files})
-    add_dependencies(docs docs_${DIRECTORY})
+    add_dependencies(docs docs_${target})
 endfunction()

--- a/cmake/main.cmake
+++ b/cmake/main.cmake
@@ -1,0 +1,49 @@
+if(PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
+    file(REMOVE "${PROJECT_SOURCE_DIR}/cpm-package-lock.cmake")
+    file(REMOVE_RECURSE "${PROJECT_SOURCE_DIR}/_deps")
+    file(REMOVE_RECURSE "${PROJECT_SOURCE_DIR}/CPM_modules")
+    message(
+        FATAL_ERROR
+            "In-source builds are a bad idea. Please make a build directory instead. "
+            "You should now remove the leftover files: CMakeCache.txt and CMakeFiles/."
+    )
+endif()
+
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD
+        20
+        CACHE INTERNAL "" FORCE)
+endif()
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS
+    ON
+    CACHE BOOL "Export compile commands to compile_commands.json." FORCE)
+
+option(INFRA_PROVIDE_GITHUB_WORKFLOWS
+       "Provide unit_test and documentation workflows" ON)
+option(INFRA_PROVIDE_CLANG_FORMAT "Provide .clang-format file" ON)
+option(INFRA_PROVIDE_CLANG_TIDY "Provide .clang-tidy file" ON)
+option(INFRA_PROVIDE_CMAKE_FORMAT "Provide .cmake-format.yaml file" ON)
+option(INFRA_PROVIDE_PRESETS "Provide cmake presets and toolchains" ON)
+option(INFRA_PROVIDE_GITIGNORE "Add provided things to .gitignore" ON)
+option(INFRA_USE_SYMLINKS "Use symlinks to provide common files" ON)
+
+if(${PROJECT_SOURCE_DIR}/cmake STREQUAL CMAKE_CURRENT_LIST_DIR)
+    set(INFRA_PROVIDE_GITHUB_WORKFLOWS OFF)
+    set(INFRA_PROVIDE_CLANG_FORMAT OFF)
+    set(INFRA_PROVIDE_CLANG_TIDY OFF)
+    set(INFRA_PROVIDE_CMAKE_FORMAT OFF)
+    set(INFRA_PROVIDE_PRESETS OFF)
+    set(INFRA_PROVIDE_GITIGNORE OFF)
+endif()
+
+include(${CMAKE_CURRENT_LIST_DIR}/cpm_recipes.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/dependencies.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/libraries.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/setup.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/quality.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/docs.cmake)
+
+if(${PROJECT_SOURCE_DIR}/cmake STREQUAL CMAKE_CURRENT_LIST_DIR)
+    add_docs(${CMAKE_CURRENT_LIST_DIR}/../docs)
+endif()


### PR DESCRIPTION
Problem:
- clients who rely on this repository at main (or at a branch name) risk having out-of-date repositories used by CPM.

Solution:
- When being used by CPM, check the current version of this repository and update if necessary.