### PR TITLE
:sparkles: Allow extra dependencies to be specified for python tests

### DIFF
--- a/cmake/coverage.cmake
+++ b/cmake/coverage.cmake
@@ -50,10 +50,10 @@ else()
     )
 endif()
 
-function(add_coverage_target name)
+function(add_test_coverage_target name)
     message(
         STATUS
-            "add_coverage_target(${name}) is disabled because CMAKE_CXX_COMPILER_ID is ${CMAKE_CXX_COMPILER_ID}."
+            "add_test_coverage_target(${name}) is disabled because CMAKE_CXX_COMPILER_ID is ${CMAKE_CXX_COMPILER_ID}."
     )
 endfunction()
 

--- a/docs/testing.adoc
+++ b/docs/testing.adoc
@@ -52,7 +52,8 @@ add_unit_test(
   my_test
   PYTEST
   FILES my_test.py
-  LIBRARIES my_lib)
+  LIBRARIES my_lib
+  EXTRA_DEPS my_header.hpp)
 ----
 
 `add_unit_test` also supports running tests using https://pytest.org[pytest]. In
@@ -61,6 +62,11 @@ the command line `--include_dirs <paths>`. And the command line options can be
 handled with pytest's
 https://docs.pytest.org/en/8.0.x/reference/reference.html#pytest.hookspec.pytest_addoption[`addoption`
 hook].
+
+NOTE: The `EXTRA_DEPS` argument allows python tests to specify extra
+dependencies that are not part of the CMake dependency tree. A `conftest.py`
+file in the same directory as any of the `FILE`​s is automatically discovered as
+such a dependency.
 
 === Fuzz tests
 


### PR DESCRIPTION
Problem:
- Python tests don't have automatically-found dependencies like C++ tests do. They typically have dependencies that are not handled through CMake.

Solution:
- Allow specifying extra dependencies with the `EXTRA_DEPS` argument to `add_unit_test(... PYTEST ...)`.

Note:
- `conftest.py` is automatically discovered as a dependency.