### PR TITLE
:rotating_light: Turn on UDL extension warning

### DIFF
--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -28,6 +28,4 @@ target_compile_options(
         -Wshadow
         $<$<CXX_COMPILER_ID:GNU>:-Wuseless-cast>
         -Wunused
-        $<$<CXX_COMPILER_ID:Clang>:-Wmissing-prototypes>
-        # warnings turned off
-        $<$<CXX_COMPILER_ID:Clang>:-Wno-gnu-string-literal-operator-template>)
+        $<$<CXX_COMPILER_ID:Clang>:-Wmissing-prototypes>)


### PR DESCRIPTION
The only library that currently needs this warning turned off is CIB, and it turns it off separately.

C++20 removes the need for this extension anyway; the warning only remains off because of crashes in clang when we remove the extension use.