### PR TITLE
:rotating_light: Update warnings for clang

### DIFF
--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -20,12 +20,14 @@ target_compile_options(
         $<$<CXX_COMPILER_ID:Clang>:-Wgcc-compat>
         $<$<CXX_COMPILER_ID:Clang>:-Wheader-hygiene>
         $<$<CXX_COMPILER_ID:Clang>:-Widiomatic-parentheses>
-        $<$<CXX_COMPILER_ID:Clang>:-Wimplicit>
+        $<$<CXX_COMPILER_ID:Clang>:-Wimplicit-fallthrough>
         $<$<CXX_COMPILER_ID:GNU>:-Wlogical-op>
         $<$<CXX_COMPILER_ID:Clang>:-Wnewline-eof>
         -Wold-style-cast
         -Woverloaded-virtual
+        $<$<CXX_COMPILER_ID:Clang>:-Wpedantic>
         -Wshadow
+        $<$<CXX_COMPILER_ID:Clang>:-Wshift-sign-overflow>
         $<$<CXX_COMPILER_ID:GNU>:-Wuseless-cast>
         -Wunused
         $<$<CXX_COMPILER_ID:Clang>:-Wmissing-prototypes>)


### PR DESCRIPTION
Note:
- `-Wimplicit` is already turned on by `-Wall`, but `-Wimplicit-fallthrough` is not on by default.
- `-Wpedantic` is a good thing.
- `-Wshift-sign-overflow` protects against a dangerous shift scenario.
- All open source libraries that depend on CICD currently compile cleanly with these warnings.