### PR TITLE
:sparkles: Add metabench for easy compile-time profiling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,10 @@ jobs:
         working-directory: ${{github.workspace}}/test/library
         run: cmake -Bbuild
 
+      - name: Build lib metabench tests
+        working-directory: ${{github.workspace}}/test/library
+        run: cmake --build build -t metabench_tests
+
       - name: Check lib quality
         working-directory: ${{github.workspace}}/test/library
         run: cmake --build build -t ci-quality

--- a/cmake/cpm_recipes.cmake
+++ b/cmake/cpm_recipes.cmake
@@ -47,3 +47,18 @@ if(NOT COMMAND boost_sml_recipe)
             "SML_BUILD_TESTS OFF")
     endmacro()
 endif()
+
+if(NOT COMMAND metabench_recipe)
+    macro(metabench_recipe VERSION)
+        add_versioned_package(
+            NAME
+            metabench
+            GITHUB_REPOSITORY
+            "ldionne/metabench"
+            GIT_TAG
+            ${VERSION}
+            DOWNLOAD_ONLY
+            YES)
+        include("${metabench_SOURCE_DIR}/metabench.cmake")
+    endmacro()
+endif()

--- a/cmake/metabench.cmake
+++ b/cmake/metabench.cmake
@@ -1,0 +1,36 @@
+if(COMMAND add_metabench_profile)
+    return()
+endif()
+
+add_custom_target(metabench_tests)
+
+macro(get_metabench)
+    if(NOT COMMAND metabench_add_chart)
+        metabench_recipe(3322ce7)
+    endif()
+endmacro()
+
+function(add_mb_profile)
+    set(singleValueArgs TARGET RANGE)
+    set(multiValueArgs TEMPLATES INCLUDE_DIRECTORIES LIBRARIES DS_ARGS
+                       CHART_ARGS)
+    cmake_parse_arguments(MB "" "${singleValueArgs}" "${multiValueArgs}"
+                          ${ARGN})
+
+    foreach(template ${MB_TEMPLATES})
+        string(REPLACE "/" "_" dataset ${template})
+        metabench_add_dataset(${dataset} "${template}" "${MB_RANGE}" NAME
+                              ${dataset} ${MB_DS_ARGS})
+        target_include_directories(${dataset} PRIVATE ${MB_INCLUDE_DIRECTORIES})
+        target_link_libraries(${dataset} PRIVATE ${MB_LIBRARIES})
+        list(APPEND datasets ${dataset})
+    endforeach()
+
+    metabench_add_chart(${MB_TARGET} DATASETS ${datasets} ${MB_CHART_ARGS})
+    add_dependencies(metabench_tests ${MB_TARGET})
+endfunction()
+
+macro(add_metabench_profile)
+    get_metabench()
+    add_mb_profile(${ARGN})
+endmacro()

--- a/cmake/quality.cmake
+++ b/cmake/quality.cmake
@@ -13,6 +13,7 @@ if(PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     include(${CMAKE_CURRENT_LIST_DIR}/sanitizers.cmake)
     include(${CMAKE_CURRENT_LIST_DIR}/test.cmake)
     include(${CMAKE_CURRENT_LIST_DIR}/benchmark.cmake)
+    include(${CMAKE_CURRENT_LIST_DIR}/metabench.cmake)
 
     include(${CMAKE_CURRENT_LIST_DIR}/warnings.cmake)
     include(${CMAKE_CURRENT_LIST_DIR}/profile.cmake)

--- a/test/library/CMakeLists.txt
+++ b/test/library/CMakeLists.txt
@@ -32,4 +32,5 @@ target_sources(
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     add_docs(docs)
     clang_tidy_interface(TARGET test_lib EXCLUDE_FILESETS exclusions)
+    add_subdirectory(test)
 endif()

--- a/test/library/test/CMakeLists.txt
+++ b/test/library/test/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_metabench_profile(
+    TARGET
+    mb_test
+    RANGE
+    "[1, 100, 200]"
+    TEMPLATES
+    test_array.cpp.erb
+    test_tuple.cpp.erb
+    DS_ARGS
+    MEDIAN_OF
+    3
+    CHART_ARGS
+    TITLE
+    "test")

--- a/test/library/test/test_array.cpp.erb
+++ b/test/library/test/test_array.cpp.erb
@@ -1,0 +1,7 @@
+#include <array>
+
+auto main() -> int {
+#if defined(METABENCH)
+    [[maybe_unused]] auto a = std::array{<%= (1..n).to_a.join(', ') %>};
+#endif
+}

--- a/test/library/test/test_tuple.cpp.erb
+++ b/test/library/test/test_tuple.cpp.erb
@@ -1,0 +1,7 @@
+#include <tuple>
+
+auto main() -> int {
+#if defined(METABENCH)
+    [[maybe_unused]] auto t = std::make_tuple(<%= (1..n).to_a.join(', ') %>);
+#endif
+}


### PR DESCRIPTION
Problem:
- Collecting data about compilation times is a manual process.

Solution:
- Add metabench tests to provide an easy way to compare compilation time effects.