### PR TITLE
:arrow_up: Update various dependencies

### DIFF
--- a/.github/workflows/asciidoctor-ghpages.yml
+++ b/.github/workflows/asciidoctor-ghpages.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install Mermaid
         run: |
-          sudo npm install -g @mermaid-js/mermaid-cli@11.2.1
+          npm install -g @mermaid-js/mermaid-cli@11.4.2
           npx puppeteer browsers install chrome-headless-shell
 
       - name: Install asciidoctor

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,9 @@ on:
 env:
   DEBIAN_FRONTEND: noninteractive
   CMAKE_GENERATOR: Ninja
-  TARGET_LLVM_VERSION: 18
-  MULL_LLVM_VERSION: 17
+  TARGET_LLVM_VERSION: 19
+  MULL_LLVM_VERSION: 18
+  MULL_VERSION: 0.24.0
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -41,7 +42,7 @@ jobs:
 
       - name: Install Mermaid
         run: |
-          sudo npm install -g @mermaid-js/mermaid-cli@11.2.1
+          npm install -g @mermaid-js/mermaid-cli@11.4.2
           npx puppeteer browsers install chrome-headless-shell
 
       - name: Install asciidoctor
@@ -84,6 +85,10 @@ jobs:
         working-directory: ${{github.workspace}}/test/library
         run: cmake -Bbuild
 
+      - name: Build lib docs
+        working-directory: ${{github.workspace}}/test/library
+        run: test $(cmake --build build -v -t docs | grep -c ERROR) == 0
+
       - name: Build lib metabench tests
         working-directory: ${{github.workspace}}/test/library
         run: cmake --build build -t metabench_tests
@@ -91,10 +96,6 @@ jobs:
       - name: Check lib quality
         working-directory: ${{github.workspace}}/test/library
         run: cmake --build build -t ci-quality
-
-      - name: Build lib docs
-        working-directory: ${{github.workspace}}/test/library
-        run: test $(cmake --build build -v -t docs | grep -c ERROR) == 0
 
       - name: Restore CPM cache
         env:
@@ -220,11 +221,9 @@ jobs:
           sudo apt install -y ninja-build
 
       - name: Install mull
-        env:
-          MULL_VERSION: 0.23.0
         run: |
-          wget https://github.com/mull-project/mull/releases/download/${{env.MULL_VERSION}}/Mull-${{env.MULL_LLVM_VERSION}}-${{env.MULL_VERSION}}-LLVM-${{env.MULL_LLVM_VERSION}}.0-ubuntu-24.04.deb
-          sudo dpkg -i Mull-${{env.MULL_LLVM_VERSION}}-${{env.MULL_VERSION}}-LLVM-${{env.MULL_LLVM_VERSION}}.0-ubuntu-24.04.deb
+          wget https://github.com/mull-project/mull/releases/download/${{env.MULL_VERSION}}/Mull-${{env.MULL_LLVM_VERSION}}-${{env.MULL_VERSION}}-LLVM-${{env.MULL_LLVM_VERSION}}.1-ubuntu-24.04.deb
+          sudo dpkg -i Mull-${{env.MULL_LLVM_VERSION}}-${{env.MULL_VERSION}}-LLVM-${{env.MULL_LLVM_VERSION}}.1-ubuntu-24.04.deb
 
       - name: Checkout PR branch
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ Where `abc123` is the version of this repository you want to depend on.
 This repository depends on:
 
 - [Boost-ext.DI](https://github.com/boost-ext/di) at version 1.3.0
-- [Catch2](https://github.com/catchorg/Catch2) at version 3.6.0
-- [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake) at version 0.38.2
-- [GoogleTest](https://github.com/google/googletest) at version 1.14.0
+- [Catch2](https://github.com/catchorg/Catch2) at version 3.8.0
+- [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake) at version 0.40.2
+- [fuzztest](https://github.com/google/fuzztest) at git hash a4f6ad5
+- [GoogleTest](https://github.com/google/googletest) at version 1.15.2
 - [GUnit](https://github.com/cpp-testing/GUnit) at version 1.14.0
-- [RapidCheck](https://github.com/emil-e/rapidcheck) at git hash 1c91f40
-- [Snitch](https://github.com/snitch-org/snitch) at version 1.2.5
+- [metabench](https://github.com/ldionne/metabench) at git hash 3322ce7
+- [RapidCheck](https://github.com/emil-e/rapidcheck) at git hash ff6af6f
+- [Snitch](https://github.com/snitch-org/snitch) at version 1.3.1
 

--- a/ci/.github/workflows/asciidoctor-ghpages.yml
+++ b/ci/.github/workflows/asciidoctor-ghpages.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install Mermaid
         run: |
-          sudo npm install -g @mermaid-js/mermaid-cli@11.2.1
+          npm install -g @mermaid-js/mermaid-cli@11.4.2
           npx puppeteer browsers install chrome-headless-shell
 
       - name: Install asciidoctor

--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -25,15 +25,23 @@ target_compile_options(sanitizer-exceptions INTERFACE -fno-sanitize=vptr)
 
 macro(get_catch2)
     if(NOT TARGET Catch2::Catch2WithMain)
-        add_versioned_package("gh:catchorg/Catch2@3.6.0")
+        add_versioned_package("gh:catchorg/Catch2@3.8.0")
         list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras)
         include(Catch)
+
+        # Workaround for https://github.com/catchorg/Catch2/issues/2910
+        add_library(clean-catch2-warnings INTERFACE)
+        target_compile_options(
+            clean-catch2-warnings
+            INTERFACE
+                $<$<AND:$<CXX_COMPILER_ID:Clang>,$<VERSION_GREATER_EQUAL:${CMAKE_CXX_COMPILER_VERSION},19>>:-Wno-c++20-extensions>
+        )
     endif()
 endmacro()
 
 macro(get_gtest)
     if(NOT TARGET gtest)
-        add_versioned_package("gh:google/googletest@1.14.0")
+        add_versioned_package("gh:google/googletest@1.15.2")
         include(GoogleTest)
     endif()
 endmacro()
@@ -45,7 +53,7 @@ macro(get_gunit)
             NAME
             gunit
             GIT_TAG
-            v1.14.0
+            467b07d
             GITHUB_REPOSITORY
             cpp-testing/GUnit
             DOWNLOAD_ONLY
@@ -55,7 +63,7 @@ endmacro()
 
 macro(get_snitch)
     if(NOT TARGET snitch::snitch)
-        add_versioned_package("gh:snitch-org/snitch@1.2.5")
+        add_versioned_package("gh:snitch-org/snitch@1.3.1")
     endif()
 endmacro()
 
@@ -90,7 +98,7 @@ endmacro()
 
 macro(add_rapidcheck)
     if(NOT TARGET rapidcheck)
-        add_versioned_package(NAME rapidcheck GIT_TAG 1c91f40 GITHUB_REPOSITORY
+        add_versioned_package(NAME rapidcheck GIT_TAG ff6af6f GITHUB_REPOSITORY
                               emil-e/rapidcheck)
         add_subdirectory(
             ${rapidcheck_SOURCE_DIR}/extras/catch
@@ -134,6 +142,7 @@ function(add_unit_test_target name)
                 catch_discover_tests(${name})
             endif()
         endif()
+        target_link_libraries(${name} PRIVATE clean-catch2-warnings)
     elseif(UNIT_GTEST)
         target_link_libraries_system(
             ${name}
@@ -402,7 +411,8 @@ function(add_fuzz_test_target name)
         rapidcheck
         rapidcheck_gtest
         rapidcheck_gmock
-        fuzztest::fuzztest_gtest_main)
+        fuzztest::fuzztest_gtest_main
+        re2::re2)
     if(FUZZ_NORANDOM)
         message(
             WARNING

--- a/docs/puppeteer_config.json
+++ b/docs/puppeteer_config.json
@@ -1,3 +1,4 @@
 {
+  "headless": 1,
   "args": ["--no-sandbox"]
 }

--- a/test/application/cmake/get_cpm.cmake
+++ b/test/application/cmake/get_cpm.cmake
@@ -1,37 +1,24 @@
-set(CPM_DOWNLOAD_VERSION 0.38.2)
+# SPDX-License-Identifier: MIT
+#
+# SPDX-FileCopyrightText: Copyright (c) 2019-2023 Lars Melchior and contributors
+
+set(CPM_DOWNLOAD_VERSION 0.40.2)
+set(CPM_HASH_SUM "c8cdc32c03816538ce22781ed72964dc864b2a34a310d3b7104812a5ca2d835d")
 
 if(CPM_SOURCE_CACHE)
-    set(CPM_DOWNLOAD_LOCATION
-        "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+  set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
 elseif(DEFINED ENV{CPM_SOURCE_CACHE})
-    set(CPM_DOWNLOAD_LOCATION
-        "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+  set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
 else()
-    set(CPM_DOWNLOAD_LOCATION
-        "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+  set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
 endif()
 
-# Expand relative path. This is important if the provided path contains a tilde
-# (~)
+# Expand relative path. This is important if the provided path contains a tilde (~)
 get_filename_component(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
 
-function(download_cpm)
-    message(STATUS "Downloading CPM.cmake to ${CPM_DOWNLOAD_LOCATION}")
-    file(
-        DOWNLOAD
-        https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
-        ${CPM_DOWNLOAD_LOCATION})
-endfunction()
-
-if(NOT (EXISTS ${CPM_DOWNLOAD_LOCATION}))
-    download_cpm()
-else()
-    # resume download if it previously failed
-    file(READ ${CPM_DOWNLOAD_LOCATION} check)
-    if("${check}" STREQUAL "")
-        download_cpm()
-    endif()
-    unset(check)
-endif()
+file(DOWNLOAD
+     https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
+     ${CPM_DOWNLOAD_LOCATION} EXPECTED_HASH SHA256=${CPM_HASH_SUM}
+)
 
 include(${CPM_DOWNLOAD_LOCATION})

--- a/test/application/test/catch2_test.cpp
+++ b/test/application/test/catch2_test.cpp
@@ -1,7 +1,10 @@
+#include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <rapidcheck/catch.h>
 
 TEST_CASE("catch2 test", "[test]") {}
+
+TEMPLATE_TEST_CASE("catch2 template test", "[test]", int) {}
 
 TEST_CASE("catch2 with rapidcheck", "[test]") {
     rc::prop("test property", [](unsigned int a) { return a * 2u == a + a; });

--- a/test/library/cmake/get_cpm.cmake
+++ b/test/library/cmake/get_cpm.cmake
@@ -1,37 +1,24 @@
-set(CPM_DOWNLOAD_VERSION 0.38.2)
+# SPDX-License-Identifier: MIT
+#
+# SPDX-FileCopyrightText: Copyright (c) 2019-2023 Lars Melchior and contributors
+
+set(CPM_DOWNLOAD_VERSION 0.40.2)
+set(CPM_HASH_SUM "c8cdc32c03816538ce22781ed72964dc864b2a34a310d3b7104812a5ca2d835d")
 
 if(CPM_SOURCE_CACHE)
-    set(CPM_DOWNLOAD_LOCATION
-        "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+  set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
 elseif(DEFINED ENV{CPM_SOURCE_CACHE})
-    set(CPM_DOWNLOAD_LOCATION
-        "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+  set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
 else()
-    set(CPM_DOWNLOAD_LOCATION
-        "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+  set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
 endif()
 
-# Expand relative path. This is important if the provided path contains a tilde
-# (~)
+# Expand relative path. This is important if the provided path contains a tilde (~)
 get_filename_component(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
 
-function(download_cpm)
-    message(STATUS "Downloading CPM.cmake to ${CPM_DOWNLOAD_LOCATION}")
-    file(
-        DOWNLOAD
-        https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
-        ${CPM_DOWNLOAD_LOCATION})
-endfunction()
-
-if(NOT (EXISTS ${CPM_DOWNLOAD_LOCATION}))
-    download_cpm()
-else()
-    # resume download if it previously failed
-    file(READ ${CPM_DOWNLOAD_LOCATION} check)
-    if("${check}" STREQUAL "")
-        download_cpm()
-    endif()
-    unset(check)
-endif()
+file(DOWNLOAD
+     https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
+     ${CPM_DOWNLOAD_LOCATION} EXPECTED_HASH SHA256=${CPM_HASH_SUM}
+)
 
 include(${CPM_DOWNLOAD_LOCATION})


### PR DESCRIPTION
- Catch2: 3.6.0 -> 3.8.0
- CPM: 0.38.2 -> 0.40.2
- GoogleTest: 1.14.0 -> 1.15.2
- rapidcheck: 1c91f40 -> ff6af6f
- Snitch: 1.2.5 -> 1.3.1
- Mull: 0.23.0 -> 0.24.0
- Switch to clang-19 as the primary compiler for tests in this repo

Note:
- A recent change to puppeteer caused mermaid doc image generation to fail. Fixed.
- Catch2 has a bug with C++17 and clang-19 detailed at https://github.com/catchorg/Catch2/issues/2910