### PR TITLE
Improve noisy mull logs and compile fail tests

### DIFF
--- a/cmake/mull.cmake
+++ b/cmake/mull.cmake
@@ -40,6 +40,9 @@ endfunction()
 
 find_mull()
 
+option(INFRA_LOUD_MULL_FAILURE
+       "Output per-target warning when mull is not available." OFF)
+
 function(add_mull_test name)
     set(options EXCLUDE_CTEST)
     set(singleValueArgs PLUGIN_DIR RUNNER_DIR)
@@ -66,10 +69,12 @@ function(add_mull_test name)
         set(MULL_RUNNER_DIR "<RUNNER_DIR not provided>")
     endif()
     if(NOT MULL_RUNNER)
-        message(
-            WARNING
-                "mull-runner-${version} not found at ${MULL_RUNNER_DIR}. mull_${name} is a failing test."
-        )
+        if(INFRA_LOUD_MULL_FAILURE)
+            message(
+                WARNING
+                    "mull-runner-${version} not found at ${MULL_RUNNER_DIR}. mull_${name} is a failing test."
+            )
+        endif()
         add_custom_target(mull_${name} ${MULL_RUNNER_NOT_FOUND_COMMAND})
         add_dependencies(mull_tests mull_${name})
         return()
@@ -83,10 +88,12 @@ function(add_mull_test name)
         set(MULL_PLUGIN_DIR "<PLUGIN_DIR not provided>")
     endif()
     if(NOT MULL_PLUGIN)
-        message(
-            WARNING
-                "mull-ir-frontend-${version} not found at ${MULL_PLUGIN_DIR}. mull_${name} is a failing test."
-        )
+        if(INFRA_LOUD_MULL_FAILURE)
+            message(
+                WARNING
+                    "mull-ir-frontend-${version} not found at ${MULL_PLUGIN_DIR}. mull_${name} is a failing test."
+            )
+        endif()
         add_custom_target(mull_${name} ${MULL_PLUGIN_NOT_FOUND_COMMAND})
         add_dependencies(mull_tests mull_${name})
         return()

--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -460,16 +460,20 @@ macro(add_fuzz_test)
 endmacro()
 
 function(add_compile_fail_test test_file)
+    set(singleValueArgs NAME)
     set(multiValueArgs INCLUDE_DIRECTORIES LIBRARIES SYSTEM_LIBRARIES)
-    cmake_parse_arguments(CF "" "" "${multiValueArgs}" ${ARGN})
+    cmake_parse_arguments(CF "" "${singleValueArgs}" "${multiValueArgs}"
+                          ${ARGN})
 
-    string(REPLACE "/" "_" test_name "${test_file}")
-    string(PREPEND test_name "EXPECT_FAIL.")
-    add_executable(${test_name} EXCLUDE_FROM_ALL ${test_file})
+    if(NOT CF_NAME)
+        string(REPLACE "/" "_" CF_NAME "${test_file}")
+    endif()
+    string(PREPEND CF_NAME "EXPECT_FAIL.")
+    add_executable(${CF_NAME} EXCLUDE_FROM_ALL ${test_file})
 
-    target_include_directories(${test_name} PRIVATE ${CF_INCLUDE_DIRECTORIES})
-    target_link_libraries(${test_name} PRIVATE ${CF_LIBRARIES})
-    target_link_libraries_system(${test_name} PRIVATE ${CF_SYSTEM_LIBRARIES})
+    target_include_directories(${CF_NAME} PRIVATE ${CF_INCLUDE_DIRECTORIES})
+    target_link_libraries(${CF_NAME} PRIVATE ${CF_LIBRARIES})
+    target_link_libraries_system(${CF_NAME} PRIVATE ${CF_SYSTEM_LIBRARIES})
 
     file(STRINGS ${test_file} pattern REGEX "// EXPECT: ")
     if(NOT pattern)
@@ -478,9 +482,8 @@ function(add_compile_fail_test test_file)
         string(REGEX REPLACE ".*// EXPECT: " "" pattern ${pattern})
     endif()
 
-    add_test(NAME ${test_name}
-             COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target
-                     ${test_name})
-    set_tests_properties(${test_name} PROPERTIES PASS_REGULAR_EXPRESSION
-                                                 "${pattern}")
+    add_test(NAME ${CF_NAME} COMMAND ${CMAKE_COMMAND} --build
+                                     ${CMAKE_BINARY_DIR} --target ${CF_NAME})
+    set_tests_properties(${CF_NAME} PROPERTIES PASS_REGULAR_EXPRESSION
+                                               "${pattern}")
 endfunction()


### PR DESCRIPTION
- Add an option for mull logs at config time: this reduces the noisy cmake output typical on the command line.
- Allow compile fail tests to be named: this allows the same code to be used for two tests with different options.