### PR TITLE
:construction_worker: Use dependabot to update provided workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,9 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/" # Location of package manifests
+    directories:
+      - "/.github/workflows"
+      - "/ci/.github/workflows"
     schedule:
       interval: "daily"
   - package-ecosystem: "gitsubmodule"


### PR DESCRIPTION
Problem:
- This repository not only has its own workflow requirements, it also provides workflows to other repositories. However the default configuration of dependabot is given "/" as a directory, which means it looks in "/.github/workflows" only.

Solution:
- Add "/ci/.github/workflows" as a manifest location as well.