### PR TITLE
:arrow_up: Update dependencies for CMake v4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ Where `abc123` is the version of this repository you want to depend on.
 
 This repository depends on:
 
-- [Boost-ext.DI](https://github.com/boost-ext/di) at version 1.3.0
+- [Boost-ext.DI](https://github.com/boost-ext/di) at version 1.3.1
 - [Catch2](https://github.com/catchorg/Catch2) at version 3.8.0
 - [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake) at version 0.40.2
 - [fuzztest](https://github.com/google/fuzztest) at git hash a4f6ad5
-- [GoogleTest](https://github.com/google/googletest) at version 1.15.2
-- [GUnit](https://github.com/cpp-testing/GUnit) at version 1.14.0
+- [GoogleTest](https://github.com/google/googletest) at version 1.16.0
+- [GUnit](https://github.com/cpp-testing/GUnit) at version 1.16.0
 - [metabench](https://github.com/ldionne/metabench) at git hash 3322ce7
 - [RapidCheck](https://github.com/emil-e/rapidcheck) at git hash ff6af6f
-- [Snitch](https://github.com/snitch-org/snitch) at version 1.3.1
+- [Snitch](https://github.com/snitch-org/snitch) at version 1.3.2
 

--- a/cmake/cpm_recipes.cmake
+++ b/cmake/cpm_recipes.cmake
@@ -59,6 +59,11 @@ if(NOT COMMAND metabench_recipe)
             ${VERSION}
             DOWNLOAD_ONLY
             YES)
+        set(policy ${CMAKE_POLICY_VERSION_MINIMUM})
+        if(NOT policy)
+            set(CMAKE_POLICY_VERSION_MINIMUM 3.27)
+        endif()
         include("${metabench_SOURCE_DIR}/metabench.cmake")
+        set(CMAKE_POLICY_VERSION_MINIMUM ${policy})
     endmacro()
 endif()

--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -41,7 +41,7 @@ endmacro()
 
 macro(get_gtest)
     if(NOT TARGET gtest)
-        add_versioned_package("gh:google/googletest@1.15.2")
+        add_versioned_package("gh:google/googletest@1.16.0")
         include(GoogleTest)
     endif()
 endmacro()
@@ -53,7 +53,7 @@ macro(get_gunit)
             NAME
             gunit
             GIT_TAG
-            467b07d
+            v1.16.0
             GITHUB_REPOSITORY
             cpp-testing/GUnit
             DOWNLOAD_ONLY
@@ -63,7 +63,7 @@ endmacro()
 
 macro(get_snitch)
     if(NOT TARGET snitch::snitch)
-        add_versioned_package("gh:snitch-org/snitch@1.3.1")
+        add_versioned_package("gh:snitch-org/snitch@1.3.2")
     endif()
 endmacro()
 
@@ -84,7 +84,19 @@ endmacro()
 
 macro(add_boost_di)
     if(NOT TARGET Boost.DI)
-        add_versioned_package("gh:boost-ext/di@1.3.0")
+        add_versioned_package(
+            NAME
+            di
+            GIT_TAG
+            v1.3.1
+            GITHUB_REPOSITORY
+            boost-ext/di
+            DOWNLOAD_ONLY
+            YES)
+        add_library(Boost.DI INTERFACE)
+        target_include_directories(
+            Boost.DI INTERFACE ${di_SOURCE_DIR}/include
+                               ${di_SOURCE_DIR}/extension/include)
     endif()
 endmacro()
 


### PR DESCRIPTION
Problem:
- CMake v4.0.0 removes support for CMake < 3.5, so calls to `cmake_minimum_required(X)` -- where X is < 3.5 -- fail.

Solution:
- Update dependencies for those that have updated.
- Workaround metabench issue.

Note:
- I am not sure that metabench is updated much these days, although I have filed an issue.
- Thanks to @kris-jusiak for a super-quick update to GUnit, Boost.DI and related dependencies.