### PR TITLE
:arrow_up: Update Boost.DI to v1.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Where `abc123` is the version of this repository you want to depend on.
 
 This repository depends on:
 
-- [Boost-ext.DI](https://github.com/boost-ext/di) at version 1.3.1
+- [Boost-ext.DI](https://github.com/boost-ext/di) at version 1.3.2
 - [Catch2](https://github.com/catchorg/Catch2) at version 3.8.0
 - [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake) at version 0.40.2
 - [fuzztest](https://github.com/google/fuzztest) at git hash a4f6ad5

--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -84,19 +84,7 @@ endmacro()
 
 macro(add_boost_di)
     if(NOT TARGET Boost.DI)
-        add_versioned_package(
-            NAME
-            di
-            GIT_TAG
-            v1.3.1
-            GITHUB_REPOSITORY
-            boost-ext/di
-            DOWNLOAD_ONLY
-            YES)
-        add_library(Boost.DI INTERFACE)
-        target_include_directories(
-            Boost.DI INTERFACE ${di_SOURCE_DIR}/include
-                               ${di_SOURCE_DIR}/extension/include)
+        add_versioned_package("gh:boost-ext/di@1.3.2")
     endif()
 endmacro()
 


### PR DESCRIPTION
Problem:
- Boost.DI used to depend on boost-headers. To work around this we were manually creating the Boost.DI library. Boost.DI dropped the boost-headers dependency in v1.3.2.

Solution:
- Use Boost.DI v1.3.2.