### PR TITLE
:sparkles: Add optional namespace prefix for generated targets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ env:
   CMAKE_GENERATOR: Ninja
   TARGET_LLVM_VERSION: 20
   MULL_LLVM_VERSION: 18
-  MULL_VERSION: 0.24.0
+  MULL_VERSION: 0.26.1
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -83,19 +83,19 @@ jobs:
           CXX: "/usr/lib/llvm-${{env.TARGET_LLVM_VERSION}}/bin/clang++"
           PR_TARGET_BRANCH: ${{ steps.target_branch.outputs.branch }}
         working-directory: ${{github.workspace}}/test/library
-        run: cmake -Bbuild
+        run: cmake -Bbuild -DINFRA_TARGET_NAMESPACE=infra
 
       - name: Build lib docs
         working-directory: ${{github.workspace}}/test/library
-        run: test $(cmake --build build -v -t docs | grep -c ERROR) == 0
+        run: test $(cmake --build build -v -t infra.docs | grep -c ERROR) == 0
 
       - name: Build lib metabench tests
         working-directory: ${{github.workspace}}/test/library
-        run: cmake --build build -t metabench_tests
+        run: cmake --build build -t infra.metabench_tests
 
       - name: Check lib quality
         working-directory: ${{github.workspace}}/test/library
-        run: cmake --build build -t ci-quality
+        run: cmake --build build -t infra.ci-quality
 
       - name: Restore CPM cache
         env:
@@ -114,7 +114,7 @@ jobs:
           CXX: "/usr/lib/llvm-${{env.TARGET_LLVM_VERSION}}/bin/clang++"
           PR_TARGET_BRANCH: ${{ steps.target_branch.outputs.branch }}
         working-directory: ${{github.workspace}}/test/application
-        run: cmake -Bbuild -DCPM_SOURCE_CACHE=~/cpm-cache
+        run: cmake -Bbuild -DCPM_SOURCE_CACHE=~/cpm-cache -DINFRA_TARGET_NAMESPACE=infra
 
       - name: Save CPM cache
         env:
@@ -128,13 +128,13 @@ jobs:
       - name: Build app and run tests
         working-directory: ${{github.workspace}}/test/application
         run: |
-          cmake --build build -t build_unit_tests
+          cmake --build build -t infra.build_unit_tests
           ctest --output-on-failure --test-dir build
 
       - name: Run benchmarks
         working-directory: ${{github.workspace}}/test/application
         run: |
-          cmake --build build -t benchmarks
+          cmake --build build -t infra.benchmarks
 
       - name: Run recipe tests
         working-directory: ${{github.workspace}}/test/application
@@ -144,7 +144,7 @@ jobs:
       - name: Generate coverage report
         working-directory: ${{github.workspace}}/test/application
         run: |
-          cmake --build build -t cpp_coverage_report
+          cmake --build build -t infra.cpp_coverage_report
           echo "<details>" >> $GITHUB_STEP_SUMMARY
           echo "<summary>Coverage report:</summary>" >> $GITHUB_STEP_SUMMARY
           cat ./build/coverage_report.txt >> $GITHUB_STEP_SUMMARY
@@ -152,7 +152,7 @@ jobs:
 
       - name: Check app quality
         working-directory: ${{github.workspace}}/test/application
-        run: cmake --build build -t ci-quality
+        run: cmake --build build -t infra.ci-quality
 
       - name: Verify app setup
         working-directory: ${{github.workspace}}/test
@@ -190,7 +190,7 @@ jobs:
           CXX: "/usr/lib/llvm-${{env.TARGET_LLVM_VERSION}}/bin/clang++"
           SANITIZERS: ${{matrix.sanitizer}}
         working-directory: ${{github.workspace}}/test/application
-        run: cmake -Bbuild -DCPM_SOURCE_CACHE=~/cpm-cache
+        run: cmake -Bbuild -DCPM_SOURCE_CACHE=~/cpm-cache -DINFRA_TARGET_NAMESPACE=infra
 
       - name: Save CPM cache
         env:
@@ -210,7 +210,7 @@ jobs:
 
       - name: Build app and run tests
         working-directory: ${{github.workspace}}/test/application
-        run: cmake --build build -t cpp_tests
+        run: cmake --build build -t infra.cpp_tests
 
   mutate:
     runs-on: ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-24.04
@@ -222,8 +222,8 @@ jobs:
 
       - name: Install mull
         run: |
-          wget https://github.com/mull-project/mull/releases/download/${{env.MULL_VERSION}}/Mull-${{env.MULL_LLVM_VERSION}}-${{env.MULL_VERSION}}-LLVM-${{env.MULL_LLVM_VERSION}}.1-ubuntu-24.04.deb
-          sudo dpkg -i Mull-${{env.MULL_LLVM_VERSION}}-${{env.MULL_VERSION}}-LLVM-${{env.MULL_LLVM_VERSION}}.1-ubuntu-24.04.deb
+          wget https://github.com/mull-project/mull/releases/download/${{env.MULL_VERSION}}/Mull-${{env.MULL_LLVM_VERSION}}-${{env.MULL_VERSION}}-LLVM-${{env.MULL_LLVM_VERSION}}.1-ubuntu-x86_64-24.04.deb
+          sudo dpkg -i Mull-${{env.MULL_LLVM_VERSION}}-${{env.MULL_VERSION}}-LLVM-${{env.MULL_LLVM_VERSION}}.1-ubuntu-x86_64-24.04.deb
 
       - name: Checkout PR branch
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -244,7 +244,7 @@ jobs:
           CC: "/usr/lib/llvm-${{env.MULL_LLVM_VERSION}}/bin/clang"
           CXX: "/usr/lib/llvm-${{env.MULL_LLVM_VERSION}}/bin/clang++"
         working-directory: ${{github.workspace}}/test/application
-        run: cmake -Bbuild -DCPM_SOURCE_CACHE=~/cpm-cache
+        run: cmake -Bbuild -DCPM_SOURCE_CACHE=~/cpm-cache -DINFRA_TARGET_NAMESPACE=infra
 
       - name: Save CPM cache
         env:
@@ -258,7 +258,7 @@ jobs:
       - name: Build app and run mull tests
         working-directory: ${{github.workspace}}/test/application
         run: |
-          cmake --build build -t mull_tests
+          cmake --build build -t infra.mull_tests
 
   merge_ok:
     runs-on: ${{ github.repository_owner == 'intel' && 'intel-' || '' }}ubuntu-24.04

--- a/cmake/benchmark.cmake
+++ b/cmake/benchmark.cmake
@@ -1,5 +1,5 @@
-add_custom_target(benchmarks)
-add_custom_target(build_benchmarks)
+add_custom_target(${INFRA_TARGET_NAMESPACE}benchmarks)
+add_custom_target(${INFRA_TARGET_NAMESPACE}build_benchmarks)
 
 function(get_nanobench)
     if(NOT TARGET nanobench)
@@ -12,22 +12,25 @@ function(add_benchmark name)
     set(multiValueArgs FILES INCLUDE_DIRECTORIES LIBRARIES SYSTEM_LIBRARIES)
     cmake_parse_arguments(BM "${options}" "" "${multiValueArgs}" ${ARGN})
 
-    add_executable(${name} EXCLUDE_FROM_ALL ${BM_FILES})
-    target_compile_options(${name} PRIVATE -O3 -march=native)
-    target_include_directories(${name} PRIVATE ${BM_INCLUDE_DIRECTORIES})
-    target_link_libraries(${name} PRIVATE ${BM_LIBRARIES})
-    target_link_libraries_system(${name} PRIVATE ${BM_SYSTEM_LIBRARIES})
-    add_dependencies(build_benchmarks ${name})
+    set(tgt_name "${INFRA_TARGET_NAMESPACE}${name}")
+    add_executable(${tgt_name} EXCLUDE_FROM_ALL ${BM_FILES})
+    target_compile_options(${tgt_name} PRIVATE -O3 -march=native)
+    target_include_directories(${tgt_name} PRIVATE ${BM_INCLUDE_DIRECTORIES})
+    target_link_libraries(${tgt_name} PRIVATE ${BM_LIBRARIES})
+    target_link_libraries_system(${tgt_name} PRIVATE ${BM_SYSTEM_LIBRARIES})
+    add_dependencies(${INFRA_TARGET_NAMESPACE}build_benchmarks ${tgt_name})
 
     if(BM_NANO)
         get_nanobench()
-        target_link_libraries_system(${name} PRIVATE nanobench)
+        target_link_libraries_system(${tgt_name} PRIVATE nanobench)
     endif()
 
     add_custom_command(
-        OUTPUT ${name}.results
-        COMMAND $<TARGET_FILE:${name}> > "${name}.results"
-        DEPENDS ${name})
-    add_custom_target(run_${name} DEPENDS ${name}.results)
-    add_dependencies(benchmarks "run_${name}")
+        OUTPUT ${tgt_name}.results
+        COMMAND $<TARGET_FILE:${tgt_name}> > "${tgt_name}.results"
+        DEPENDS ${tgt_name})
+    add_custom_target(${INFRA_TARGET_NAMESPACE}run_${name}
+                      DEPENDS ${tgt_name}.results)
+    add_dependencies(${INFRA_TARGET_NAMESPACE}benchmarks
+                     "${INFRA_TARGET_NAMESPACE}run_${name}")
 endfunction()

--- a/cmake/black.cmake
+++ b/cmake/black.cmake
@@ -11,8 +11,10 @@ else()
         COMMAND ${CMAKE_COMMAND} -E echo
         "Cannot run black because black not found." COMMAND ${CMAKE_COMMAND} -E
         false)
-    add_custom_target(check-black-format ${BLACK_NOT_FOUND_COMMAND_ARGS})
-    add_custom_target(fix-black-format ${BLACK_NOT_FOUND_COMMAND_ARGS})
+    add_custom_target(${INFRA_TARGET_NAMESPACE}check-black-format
+                      ${BLACK_NOT_FOUND_COMMAND_ARGS})
+    add_custom_target(${INFRA_TARGET_NAMESPACE}fix-black-format
+                      ${BLACK_NOT_FOUND_COMMAND_ARGS})
     return()
 endif()
 
@@ -29,7 +31,7 @@ function(add_black_format_target name)
         OUTPUT_STRIP_TRAILING_WHITESPACE)
 
     add_custom_target(
-        "${name}-black-format"
+        "${INFRA_TARGET_NAMESPACE}${name}-black-format"
         COMMAND
             ${CMAKE_COMMAND} "-DGIT_PROGRAM=${GIT_PROGRAM}"
             "-DBLACK_PROGRAM=${BLACK_PROGRAM}" "-DFORMAT_FUNC=${name}"
@@ -39,5 +41,7 @@ endfunction()
 
 add_black_format_target("check")
 add_black_format_target("fix")
-add_dependencies(quality check-black-format)
-add_dependencies(ci-quality check-black-format)
+add_dependencies(${INFRA_TARGET_NAMESPACE}quality
+                 ${INFRA_TARGET_NAMESPACE}check-black-format)
+add_dependencies(${INFRA_TARGET_NAMESPACE}ci-quality
+                 ${INFRA_TARGET_NAMESPACE}check-black-format)

--- a/cmake/clang-tidy.cmake
+++ b/cmake/clang-tidy.cmake
@@ -17,18 +17,21 @@ endif()
 find_program(CLANG_TIDY_PROGRAM "clang-tidy" HINTS ${CT_ROOT})
 if(CLANG_TIDY_PROGRAM)
     message(STATUS "clang-tidy found at ${CLANG_TIDY_PROGRAM}.")
-    add_custom_target(clang-tidy)
-    add_custom_target(clang-tidy-branch-diff)
-    add_dependencies(quality clang-tidy)
-    add_dependencies(ci-quality clang-tidy-branch-diff)
+    add_custom_target(${INFRA_TARGET_NAMESPACE}clang-tidy)
+    add_custom_target(${INFRA_TARGET_NAMESPACE}clang-tidy-branch-diff)
+    add_dependencies(${INFRA_TARGET_NAMESPACE}quality
+                     ${INFRA_TARGET_NAMESPACE}clang-tidy)
+    add_dependencies(${INFRA_TARGET_NAMESPACE}ci-quality
+                     ${INFRA_TARGET_NAMESPACE}clang-tidy-branch-diff)
 else()
     message(STATUS "clang-tidy not found. Adding dummy target.")
     set(CLANG_TIDY_NOT_FOUND_COMMAND_ARGS
         COMMAND ${CMAKE_COMMAND} -E echo
         "Cannot run clang-tidy because clang-tidy not found." COMMAND
         ${CMAKE_COMMAND} -E false)
-    add_custom_target(clang-tidy ${CLANG_TIDY_NOT_FOUND_COMMAND_ARGS})
-    add_custom_target(clang-tidy-branch-diff
+    add_custom_target(${INFRA_TARGET_NAMESPACE}clang-tidy
+                      ${CLANG_TIDY_NOT_FOUND_COMMAND_ARGS})
+    add_custom_target(${INFRA_TARGET_NAMESPACE}clang-tidy-branch-diff
                       ${CLANG_TIDY_NOT_FOUND_COMMAND_ARGS})
     return()
 endif()
@@ -38,7 +41,7 @@ set(CREATE_CLANG_TIDIABLE_SCRIPT
     CACHE STRING "" FORCE)
 
 function(clang_tidy_header HEADER TARGET)
-    filename_to_target(${HEADER} CT_NAME "clang-tidy_")
+    filename_to_target(${HEADER} CT_NAME "${INFRA_TARGET_NAMESPACE}clang-tidy_")
     set(CPP_NAME
         "${CMAKE_BINARY_DIR}/generated-sources/${TARGET}/${CT_NAME}.cpp")
 
@@ -58,7 +61,7 @@ function(clang_tidy_header HEADER TARGET)
             "${CLANG_TIDY_PROGRAM};-p;${CMAKE_BINARY_DIR};-header-filter=${HEADER}"
     )
 
-    add_dependencies(clang-tidy "${CT_NAME}")
+    add_dependencies(${INFRA_TARGET_NAMESPACE}clang-tidy "${CT_NAME}")
 endfunction()
 
 function(clang_tidy_dirs TARGET EXCLUDE_DIRS EXCLUDE_FILES)
@@ -126,10 +129,10 @@ function(clang_tidy_interface)
         clang_tidy_dirs(${CT_TARGET} "${CT_EXCLUDE_DIRS}" "${CT_EXCLUDE_FILES}")
     endif()
 
-    compute_branch_diff(clang-tidy ".hpp")
+    compute_branch_diff(${INFRA_TARGET_NAMESPACE}clang-tidy ".hpp")
 endfunction()
 
-if(NOT TARGET clang-tidy-canary)
+if(NOT TARGET ${INFRA_TARGET_NAMESPACE}clang-tidy-canary)
     message(STATUS "Adding clang-tidy-canary target for ${CMAKE_SOURCE_DIR}")
     add_custom_command(
         OUTPUT clang_tidy_canary.alive
@@ -137,7 +140,10 @@ if(NOT TARGET clang-tidy-canary)
         COMMAND "!" "[" "-s" "clang_tidy.log" "]"
         COMMAND ${CMAKE_COMMAND} "-E" "touch" "clang_tidy_canary.alive"
         DEPENDS ${CMAKE_SOURCE_DIR}/.clang-tidy)
-    add_custom_target(clang-tidy-canary DEPENDS clang_tidy_canary.alive)
-    add_dependencies(clang-tidy clang-tidy-canary)
-    add_dependencies(clang-tidy-branch-diff clang-tidy-canary)
+    add_custom_target(${INFRA_TARGET_NAMESPACE}clang-tidy-canary
+                      DEPENDS clang_tidy_canary.alive)
+    add_dependencies(${INFRA_TARGET_NAMESPACE}clang-tidy
+                     ${INFRA_TARGET_NAMESPACE}clang-tidy-canary)
+    add_dependencies(${INFRA_TARGET_NAMESPACE}clang-tidy-branch-diff
+                     ${INFRA_TARGET_NAMESPACE}clang-tidy-canary)
 endif()

--- a/cmake/coverage.cmake
+++ b/cmake/coverage.cmake
@@ -1,11 +1,12 @@
-add_library(coverage INTERFACE)
+add_library(${INFRA_TARGET_NAMESPACE}coverage INTERFACE)
 target_compile_options(
-    coverage INTERFACE $<$<CXX_COMPILER_ID:Clang>:-fprofile-instr-generate>
-                       $<$<CXX_COMPILER_ID:Clang>:-fcoverage-mapping>)
-target_link_options(coverage INTERFACE
+    ${INFRA_TARGET_NAMESPACE}coverage
+    INTERFACE $<$<CXX_COMPILER_ID:Clang>:-fprofile-instr-generate>
+              $<$<CXX_COMPILER_ID:Clang>:-fcoverage-mapping>)
+target_link_options(${INFRA_TARGET_NAMESPACE}coverage INTERFACE
                     $<$<CXX_COMPILER_ID:Clang>:-fprofile-instr-generate>)
 
-add_custom_target(cpp_coverage_report)
+add_custom_target(${INFRA_TARGET_NAMESPACE}cpp_coverage_report)
 
 find_program(LLVM_PROFDATA_PROGRAM "llvm-profdata" HINTS ${CT_ROOT})
 if(LLVM_PROFDATA_PROGRAM)
@@ -14,14 +15,14 @@ if(LLVM_PROFDATA_PROGRAM)
     if(LLVM_COV_PROGRAM)
         message(STATUS "llvm-cov found at ${LLVM_COV_PROGRAM}.")
 
-        add_custom_target(cpp_coverage)
+        add_custom_target(${INFRA_TARGET_NAMESPACE}cpp_coverage)
         add_custom_command(
             OUTPUT ${PROJECT_BINARY_DIR}/combined.profdata
             COMMAND
                 "${LLVM_PROFDATA_PROGRAM}" merge -sparse
                 ${PROJECT_BINARY_DIR}/coverage/*.profdata -o
                 ${PROJECT_BINARY_DIR}/combined.profdata
-            DEPENDS cpp_coverage)
+            DEPENDS ${INFRA_TARGET_NAMESPACE}cpp_coverage)
 
         add_custom_command(
             OUTPUT ${PROJECT_BINARY_DIR}/coverage_report.txt
@@ -29,14 +30,15 @@ if(LLVM_PROFDATA_PROGRAM)
                 "${LLVM_COV_PROGRAM}" report -show-instantiation-summary
                 $<$<VERSION_GREATER_EQUAL:${CMAKE_CXX_COMPILER_VERSION},18>:-show-mcdc-summary>
                 -instr-profile=${PROJECT_BINARY_DIR}/combined.profdata
-                $<LIST:TRANSFORM,$<TARGET_GENEX_EVAL:cpp_coverage,$<TARGET_PROPERTY:cpp_coverage,COVERAGE_OBJECTS>>,PREPEND,--object=>
+                $<LIST:TRANSFORM,$<TARGET_GENEX_EVAL:${INFRA_TARGET_NAMESPACE}cpp_coverage,$<TARGET_PROPERTY:${INFRA_TARGET_NAMESPACE}cpp_coverage,COVERAGE_OBJECTS>>,PREPEND,--object=>
                 > ${PROJECT_BINARY_DIR}/coverage_report.txt
             COMMAND_EXPAND_LISTS VERBATIM
             DEPENDS ${PROJECT_BINARY_DIR}/combined.profdata)
-        add_custom_target(cpp_cov_report
+        add_custom_target(${INFRA_TARGET_NAMESPACE}cpp_cov_report
                           DEPENDS ${PROJECT_BINARY_DIR}/coverage_report.txt)
 
-        add_dependencies(cpp_coverage_report cpp_cov_report)
+        add_dependencies(${INFRA_TARGET_NAMESPACE}cpp_coverage_report
+                         ${INFRA_TARGET_NAMESPACE}cpp_cov_report)
     else()
         message(
             STATUS
@@ -68,7 +70,8 @@ function(add_test_coverage_target name)
             COMMAND env "LLVM_PROFILE_FILE=coverage/${name}.profraw"
                     $<TARGET_FILE:${name}>
             DEPENDS run_${name})
-        add_custom_target(raw_coverage_${name} DEPENDS coverage/${name}.profraw)
+        add_custom_target(${INFRA_TARGET_NAMESPACE}raw_coverage_${name}
+                          DEPENDS coverage/${name}.profraw)
 
         add_custom_command(
             OUTPUT ${PROJECT_BINARY_DIR}/coverage/${name}.profdata
@@ -76,9 +79,9 @@ function(add_test_coverage_target name)
                 "${LLVM_PROFDATA_PROGRAM}" merge -sparse
                 coverage/${name}.profraw -o
                 ${PROJECT_BINARY_DIR}/coverage/${name}.profdata
-            DEPENDS raw_coverage_${name})
+            DEPENDS ${INFRA_TARGET_NAMESPACE}raw_coverage_${name})
         add_custom_target(
-            indexed_coverage_${name}
+            ${INFRA_TARGET_NAMESPACE}indexed_coverage_${name}
             DEPENDS ${PROJECT_BINARY_DIR}/coverage/${name}.profdata)
 
         add_custom_command(
@@ -90,14 +93,15 @@ function(add_test_coverage_target name)
                 -object $<TARGET_FILE:${name}> >
                 ${PROJECT_BINARY_DIR}/coverage/${name}.coverage_report.txt
             COMMAND_EXPAND_LISTS VERBATIM
-            DEPENDS indexed_coverage_${name})
+            DEPENDS ${INFRA_TARGET_NAMESPACE}indexed_coverage_${name})
         add_custom_target(
-            coverage_report_${name}
+            ${INFRA_TARGET_NAMESPACE}coverage_report_${name}
             DEPENDS ${PROJECT_BINARY_DIR}/coverage/${name}.coverage_report.txt)
 
-        add_dependencies(cpp_coverage "indexed_coverage_${name}")
+        add_dependencies(${INFRA_TARGET_NAMESPACE}cpp_coverage
+                         "${INFRA_TARGET_NAMESPACE}indexed_coverage_${name}")
         set_property(
-            TARGET cpp_coverage
+            TARGET ${INFRA_TARGET_NAMESPACE}cpp_coverage
             APPEND
             PROPERTY COVERAGE_OBJECTS $<TARGET_FILE:${name}>)
     endif()

--- a/cmake/diagnostics.cmake
+++ b/cmake/diagnostics.cmake
@@ -1,7 +1,7 @@
-add_library(diagnostics INTERFACE)
+add_library(${INFRA_TARGET_NAMESPACE}diagnostics INTERFACE)
 
 target_compile_options(
-    diagnostics
+    ${INFRA_TARGET_NAMESPACE}diagnostics
     INTERFACE
         $<$<CXX_COMPILER_ID:Clang>:-ferror-limit=8>
         $<$<CXX_COMPILER_ID:GNU>:-fmax-errors=8>

--- a/cmake/docs.cmake
+++ b/cmake/docs.cmake
@@ -20,14 +20,15 @@ endfunction()
 find_program(ASCIIDOCTOR_PROGRAM "asciidoctor")
 if(ASCIIDOCTOR_PROGRAM)
     message(STATUS "asciidoctor found at ${ASCIIDOCTOR_PROGRAM}.")
-    add_custom_target(docs ALL)
+    add_custom_target(${INFRA_TARGET_NAMESPACE}docs ALL)
 else()
     message(STATUS "asciidoctor not found. Adding dummy target.")
     set(ASCIIDOCTOR_NOT_FOUND_COMMAND_ARGS
         COMMAND ${CMAKE_COMMAND} -E echo
         "Cannot run asciidoctor because asciidoctor not found." COMMAND
         ${CMAKE_COMMAND} -E false)
-    add_custom_target(docs ${ASCIIDOCTOR_NOT_FOUND_COMMAND_ARGS})
+    add_custom_target(${INFRA_TARGET_NAMESPACE}docs
+                      ${ASCIIDOCTOR_NOT_FOUND_COMMAND_ARGS})
     return()
 endif()
 
@@ -36,8 +37,9 @@ function(add_docs DIRECTORY)
     file(RELATIVE_PATH rel_dir ${CMAKE_SOURCE_DIR} ${real_dir})
     string(REPLACE "/" "_" target ${rel_dir})
     add_custom_target(
-        docs_${target} DEPENDS ${CMAKE_BINARY_DIR}/${rel_dir}/index.html
-                               ${CMAKE_BINARY_DIR}/${rel_dir}/static)
+        ${INFRA_TARGET_NAMESPACE}docs_${target}
+        DEPENDS ${CMAKE_BINARY_DIR}/${rel_dir}/index.html
+                ${CMAKE_BINARY_DIR}/${rel_dir}/static)
     if(EXISTS ${CMAKE_SOURCE_DIR}/${rel_dir}/static)
         add_custom_command(
             OUTPUT ${CMAKE_BINARY_DIR}/${rel_dir}/static
@@ -61,5 +63,6 @@ function(add_docs DIRECTORY)
             ${CMAKE_SOURCE_DIR}/${rel_dir}/index.adoc -D
             ${CMAKE_BINARY_DIR}/${rel_dir}
         DEPENDS ${doc_files})
-    add_dependencies(docs docs_${target})
+    add_dependencies(${INFRA_TARGET_NAMESPACE}docs
+                     ${INFRA_TARGET_NAMESPACE}docs_${target})
 endfunction()

--- a/cmake/format.cmake
+++ b/cmake/format.cmake
@@ -13,5 +13,26 @@ add_versioned_package(
     OPTIONS
     "CMAKE_FORMAT_EXCLUDE cmake/get_cpm.cmake")
 
-add_dependencies(quality check-clang-format check-cmake-format)
-add_dependencies(ci-quality check-clang-format check-cmake-format)
+if(NOT "${INFRA_TARGET_NAMESPACE}" STREQUAL "")
+    add_custom_target(${INFRA_TARGET_NAMESPACE}clang-format
+                      DEPENDS clang-format)
+    add_custom_target(${INFRA_TARGET_NAMESPACE}check-clang-format
+                      DEPENDS check-clang-format)
+    add_custom_target(${INFRA_TARGET_NAMESPACE}fix-clang-format
+                      DEPENDS fix-clang-format)
+    add_custom_target(${INFRA_TARGET_NAMESPACE}cmake-format
+                      DEPENDS cmake-format)
+    add_custom_target(${INFRA_TARGET_NAMESPACE}check-cmake-format
+                      DEPENDS check-cmake-format)
+    add_custom_target(${INFRA_TARGET_NAMESPACE}fix-cmake-format
+                      DEPENDS fix-cmake-format)
+endif()
+
+add_dependencies(
+    ${INFRA_TARGET_NAMESPACE}quality
+    ${INFRA_TARGET_NAMESPACE}check-clang-format
+    ${INFRA_TARGET_NAMESPACE}check-cmake-format)
+add_dependencies(
+    ${INFRA_TARGET_NAMESPACE}ci-quality
+    ${INFRA_TARGET_NAMESPACE}check-clang-format
+    ${INFRA_TARGET_NAMESPACE}check-cmake-format)

--- a/cmake/main.cmake
+++ b/cmake/main.cmake
@@ -47,6 +47,15 @@ if(${PROJECT_SOURCE_DIR}/cmake STREQUAL CMAKE_CURRENT_LIST_DIR)
     set(INFRA_PROVIDE_GITIGNORE OFF)
 endif()
 
+if(DEFINED INFRA_TARGET_NAMESPACE)
+    if(NOT INFRA_TARGET_NAMESPACE MATCHES "\\.$")
+        set(INFRA_TARGET_NAMESPACE
+            "${INFRA_TARGET_NAMESPACE}."
+            CACHE STRING
+                  "Prefix namespace for infrastructure-generated targets" FORCE)
+    endif()
+endif()
+
 include(${CMAKE_CURRENT_LIST_DIR}/cpm_recipes.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/dependencies.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/libraries.cmake)

--- a/cmake/metabench.cmake
+++ b/cmake/metabench.cmake
@@ -2,7 +2,7 @@ if(COMMAND add_metabench_profile)
     return()
 endif()
 
-add_custom_target(metabench_tests)
+add_custom_target(${INFRA_TARGET_NAMESPACE}metabench_tests)
 
 macro(get_metabench)
     if(NOT COMMAND metabench_add_chart)
@@ -19,6 +19,7 @@ function(add_mb_profile)
 
     foreach(template ${MB_TEMPLATES})
         string(REPLACE "/" "_" dataset ${template})
+        set(dataset "${INFRA_TARGET_NAMESPACE}${dataset}")
         metabench_add_dataset(${dataset} "${template}" "${MB_RANGE}" NAME
                               ${dataset} ${MB_DS_ARGS})
         target_include_directories(${dataset} PRIVATE ${MB_INCLUDE_DIRECTORIES})
@@ -27,7 +28,7 @@ function(add_mb_profile)
     endforeach()
 
     metabench_add_chart(${MB_TARGET} DATASETS ${datasets} ${MB_CHART_ARGS})
-    add_dependencies(metabench_tests ${MB_TARGET})
+    add_dependencies(${INFRA_TARGET_NAMESPACE}metabench_tests ${MB_TARGET})
 endfunction()
 
 macro(add_metabench_profile)
@@ -117,7 +118,8 @@ function(add_mb_comparison)
     endif()
 
     string(REPLACE "/" "_" dataset ${MB_TEMPLATE})
-    foreach(alt in ITEMS old new)
+    foreach(alt in ITEMS ${INFRA_TARGET_NAMESPACE}old
+                         ${INFRA_TARGET_NAMESPACE}new)
         metabench_add_dataset(
             "${alt}_${dataset}" "${MB_TEMPLATE}" "${MB_RANGE}" NAME
             "${alt}_${dataset}" ${MB_DS_ARGS})
@@ -125,11 +127,15 @@ function(add_mb_comparison)
                                    PRIVATE ${MB_INCLUDE_DIRECTORIES})
         target_link_libraries("${alt}_${dataset}" PRIVATE ${MB_LIBRARIES})
     endforeach()
-    target_link_libraries("old_${dataset}" PRIVATE ${orig_lib})
-    target_link_libraries("new_${dataset}" PRIVATE ${MB_LIBRARY})
+    target_link_libraries("${INFRA_TARGET_NAMESPACE}old_${dataset}"
+                          PRIVATE ${orig_lib})
+    target_link_libraries("${INFRA_TARGET_NAMESPACE}new_${dataset}"
+                          PRIVATE ${MB_LIBRARY})
 
-    metabench_add_chart(${MB_TARGET} DATASETS old_${dataset} new_${dataset}
-                        ${MB_CHART_ARGS})
+    metabench_add_chart(
+        ${MB_TARGET} DATASETS ${INFRA_TARGET_NAMESPACE}old_${dataset}
+        ${INFRA_TARGET_NAMESPACE}new_${dataset} ${MB_CHART_ARGS})
+    add_dependencies(${INFRA_TARGET_NAMESPACE}metabench_tests ${MB_TARGET})
 endfunction()
 
 macro(add_metabench_comparison)

--- a/cmake/mull.cmake
+++ b/cmake/mull.cmake
@@ -1,4 +1,4 @@
-add_custom_target(mull_tests)
+add_custom_target(${INFRA_TARGET_NAMESPACE}mull_tests)
 
 option(INFRA_LOUD_MULL_FAILURE
        "Output per-target warning when mull is not available." OFF)
@@ -77,8 +77,10 @@ function(add_mull_test name)
                     "mull-runner-${version} not found at ${MULL_RUNNER_DIR}. mull_${name} is a failing test."
             )
         endif()
-        add_custom_target(mull_${name} ${MULL_RUNNER_NOT_FOUND_COMMAND})
-        add_dependencies(mull_tests mull_${name})
+        add_custom_target(${INFRA_TARGET_NAMESPACE}mull_${name}
+                          ${MULL_RUNNER_NOT_FOUND_COMMAND})
+        add_dependencies(${INFRA_TARGET_NAMESPACE}mull_tests
+                         ${INFRA_TARGET_NAMESPACE}mull_${name})
         return()
     endif()
 
@@ -96,17 +98,20 @@ function(add_mull_test name)
                     "mull-ir-frontend-${version} not found at ${MULL_PLUGIN_DIR}. mull_${name} is a failing test."
             )
         endif()
-        add_custom_target(mull_${name} ${MULL_PLUGIN_NOT_FOUND_COMMAND})
-        add_dependencies(mull_tests mull_${name})
+        add_custom_target(${INFRA_TARGET_NAMESPACE}mull_${name}
+                          ${MULL_PLUGIN_NOT_FOUND_COMMAND})
+        add_dependencies(${INFRA_TARGET_NAMESPACE}mull_tests
+                         ${INFRA_TARGET_NAMESPACE}mull_${name})
         return()
     endif()
 
     target_compile_options(${name} PRIVATE -fpass-plugin=${MULL_PLUGIN} -O0 -g
                                            -grecord-command-line)
-    target_link_libraries(${name} PRIVATE coverage)
+    target_link_libraries(${name} PRIVATE ${INFRA_TARGET_NAMESPACE}coverage)
 
     set(mull_test_command $<TARGET_FILE:${name}>)
-    add_custom_target(mull_${name} DEPENDS ${name}.mull)
+    add_custom_target(${INFRA_TARGET_NAMESPACE}mull_${name}
+                      DEPENDS ${name}.mull)
     add_custom_command(
         OUTPUT ${name}.mull
         COMMAND ${MULL_RUNNER} ${MULL_RUNNER_ARGS} ${mull_test_command}
@@ -120,5 +125,6 @@ function(add_mull_test name)
                          ${mull_test_command} COMMAND_EXPAND_LISTS)
     endif()
 
-    add_dependencies(mull_tests mull_${name})
+    add_dependencies(${INFRA_TARGET_NAMESPACE}mull_tests
+                     ${INFRA_TARGET_NAMESPACE}mull_${name})
 endfunction()

--- a/cmake/mypy.cmake
+++ b/cmake/mypy.cmake
@@ -5,18 +5,22 @@ endfunction()
 find_program(MYPY_PROGRAM "mypy")
 if(MYPY_PROGRAM)
     message(STATUS "mypy found at ${MYPY_PROGRAM}")
-    add_custom_target(mypy-lint)
-    add_custom_target(mypy-lint-branch-diff)
-    add_dependencies(quality mypy-lint)
-    add_dependencies(ci-quality mypy-lint-branch-diff)
+    add_custom_target(${INFRA_TARGET_NAMESPACE}mypy-lint)
+    add_custom_target(${INFRA_TARGET_NAMESPACE}mypy-lint-branch-diff)
+    add_dependencies(${INFRA_TARGET_NAMESPACE}quality
+                     ${INFRA_TARGET_NAMESPACE}mypy-lint)
+    add_dependencies(${INFRA_TARGET_NAMESPACE}ci-quality
+                     ${INFRA_TARGET_NAMESPACE}mypy-lint-branch-diff)
 else()
     message(STATUS "mypy not found. Adding dummy target.")
     set(MYPY_NOT_FOUND_COMMAND_ARGS
         COMMAND ${CMAKE_COMMAND} -E echo
         "Cannot run mypy because mypy not found." COMMAND ${CMAKE_COMMAND} -E
         false)
-    add_custom_target(mypy-lint ${MYPY_NOT_FOUND_COMMAND_ARGS})
-    add_custom_target(mypy-lint-branch-diff ${MYPY_NOT_FOUND_COMMAND_ARGS})
+    add_custom_target(${INFRA_TARGET_NAMESPACE}mypy-lint
+                      ${MYPY_NOT_FOUND_COMMAND_ARGS})
+    add_custom_target(${INFRA_TARGET_NAMESPACE}mypy-lint-branch-diff
+                      ${MYPY_NOT_FOUND_COMMAND_ARGS})
     return()
 endif()
 
@@ -29,7 +33,7 @@ function(mypy_lint)
 
     foreach(file ${ML_FILES})
         file(REAL_PATH ${file} file)
-        filename_to_target(${file} target "mypy-lint_")
+        filename_to_target(${file} target "${INFRA_TARGET_NAMESPACE}mypy-lint_")
         set(artifact "${CMAKE_CURRENT_BINARY_DIR}/${target}.linted")
 
         add_custom_target(${target} DEPENDS ${artifact})
@@ -41,8 +45,8 @@ function(mypy_lint)
             DEPENDS ${file}
             COMMAND_EXPAND_LISTS
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-        add_dependencies(mypy-lint ${target})
+        add_dependencies(${INFRA_TARGET_NAMESPACE}mypy-lint ${target})
     endforeach()
 
-    compute_branch_diff(mypy-lint ".py")
+    compute_branch_diff(${INFRA_TARGET_NAMESPACE}mypy-lint ".py")
 endfunction()

--- a/cmake/profile.cmake
+++ b/cmake/profile.cmake
@@ -1,6 +1,6 @@
-add_library(profile-compilation INTERFACE)
+add_library(${INFRA_TARGET_NAMESPACE}profile-compilation INTERFACE)
 
 target_compile_options(
-    profile-compilation
+    ${INFRA_TARGET_NAMESPACE}profile-compilation
     INTERFACE -ftime-report $<$<CXX_COMPILER_ID:Clang>:-ftime-trace>
               $<$<CXX_COMPILER_ID:Clang>:-ftime-trace-granularity=10>)

--- a/cmake/quality.cmake
+++ b/cmake/quality.cmake
@@ -1,10 +1,10 @@
-if(TARGET quality)
+if(TARGET ${INFRA_TARGET_NAMESPACE}quality)
     return()
 endif()
 
 if(PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-    add_custom_target(quality)
-    add_custom_target(ci-quality)
+    add_custom_target(${INFRA_TARGET_NAMESPACE}quality)
+    add_custom_target(${INFRA_TARGET_NAMESPACE}ci-quality)
 
     get_filename_component(CT_ROOT ${CMAKE_CXX_COMPILER} DIRECTORY)
 

--- a/cmake/sanitizers.cmake
+++ b/cmake/sanitizers.cmake
@@ -1,4 +1,4 @@
-add_library(sanitizers INTERFACE)
+add_library(${INFRA_TARGET_NAMESPACE}sanitizers INTERFACE)
 
 if(DEFINED ENV{SANITIZERS})
     set(SANITIZERS $ENV{SANITIZERS})
@@ -6,21 +6,23 @@ endif()
 
 if(SANITIZERS)
     target_compile_options(
-        sanitizers
+        ${INFRA_TARGET_NAMESPACE}sanitizers
         INTERFACE -g -fno-omit-frame-pointer -fno-optimize-sibling-calls
                   -fsanitize=${SANITIZERS} -fno-sanitize-recover=${SANITIZERS})
 
     string(REGEX MATCH "memory" SANITIZER_MEMORY "${SANITIZERS}")
     if(SANITIZER_MEMORY)
-        target_compile_options(sanitizers
+        target_compile_options(${INFRA_TARGET_NAMESPACE}sanitizers
                                INTERFACE -fsanitize-memory-track-origins)
     endif()
 
     string(REGEX MATCH "address|memory|thread" SANITIZER_NEW_DEL
                  "${SANITIZERS}")
     if(SANITIZER_NEW_DEL)
-        target_compile_definitions(sanitizers INTERFACE SANITIZER_NEW_DEL)
+        target_compile_definitions(${INFRA_TARGET_NAMESPACE}sanitizers
+                                   INTERFACE SANITIZER_NEW_DEL)
     endif()
 
-    target_link_options(sanitizers INTERFACE -fsanitize=${SANITIZERS})
+    target_link_options(${INFRA_TARGET_NAMESPACE}sanitizers INTERFACE
+                        -fsanitize=${SANITIZERS})
 endif()

--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -1,10 +1,12 @@
 option(BUILD_TESTING "" OFF)
 include(CTest)
-add_custom_target(unit_tests)
-add_custom_target(cpp_tests)
-add_custom_target(python_tests)
-add_custom_target(build_unit_tests)
-add_dependencies(unit_tests cpp_tests python_tests)
+add_custom_target(${INFRA_TARGET_NAMESPACE}unit_tests)
+add_custom_target(${INFRA_TARGET_NAMESPACE}cpp_tests)
+add_custom_target(${INFRA_TARGET_NAMESPACE}python_tests)
+add_custom_target(${INFRA_TARGET_NAMESPACE}build_unit_tests)
+add_dependencies(
+    ${INFRA_TARGET_NAMESPACE}unit_tests ${INFRA_TARGET_NAMESPACE}cpp_tests
+    ${INFRA_TARGET_NAMESPACE}python_tests)
 
 set(CMAKE_TESTING_ENABLED
     1
@@ -20,8 +22,9 @@ set(MEMORYCHECK_COMMAND_OPTIONS
 configure_file(${CMAKE_ROOT}/Modules/DartConfiguration.tcl.in
                ${PROJECT_BINARY_DIR}/DartConfiguration.tcl)
 
-add_library(sanitizer-exceptions INTERFACE)
-target_compile_options(sanitizer-exceptions INTERFACE -fno-sanitize=vptr)
+add_library(${INFRA_TARGET_NAMESPACE}sanitizer-exceptions INTERFACE)
+target_compile_options(${INFRA_TARGET_NAMESPACE}sanitizer-exceptions
+                       INTERFACE -fno-sanitize=vptr)
 
 macro(get_catch2)
     if(NOT TARGET Catch2::Catch2WithMain)
@@ -30,9 +33,9 @@ macro(get_catch2)
         include(Catch)
 
         # Workaround for https://github.com/catchorg/Catch2/issues/2910
-        add_library(clean-catch2-warnings INTERFACE)
+        add_library(${INFRA_TARGET_NAMESPACE}clean-catch2-warnings INTERFACE)
         target_compile_options(
-            clean-catch2-warnings
+            ${INFRA_TARGET_NAMESPACE}clean-catch2-warnings
             INTERFACE
                 $<$<AND:$<CXX_COMPILER_ID:Clang>,$<VERSION_GREATER_EQUAL:${CMAKE_CXX_COMPILER_VERSION},19>>:-Wno-c++20-extensions>
         )
@@ -121,8 +124,8 @@ function(add_unit_test_target name)
     target_include_directories(${name} PRIVATE ${UNIT_INCLUDE_DIRECTORIES})
     target_link_libraries(${name} PRIVATE ${UNIT_LIBRARIES})
     target_link_libraries_system(${name} PRIVATE ${UNIT_SYSTEM_LIBRARIES})
-    target_link_libraries(${name} PRIVATE sanitizers)
-    add_dependencies(build_unit_tests ${name})
+    target_link_libraries(${name} PRIVATE ${INFRA_TARGET_NAMESPACE}sanitizers)
+    add_dependencies(${INFRA_TARGET_NAMESPACE}build_unit_tests ${name})
 
     if(UNIT_CATCH2)
         target_link_libraries_system(${name} PRIVATE Catch2::Catch2WithMain
@@ -142,7 +145,8 @@ function(add_unit_test_target name)
                 catch_discover_tests(${name})
             endif()
         endif()
-        target_link_libraries(${name} PRIVATE clean-catch2-warnings)
+        target_link_libraries(
+            ${name} PRIVATE ${INFRA_TARGET_NAMESPACE}clean-catch2-warnings)
     elseif(UNIT_GTEST)
         target_link_libraries_system(
             ${name}
@@ -182,7 +186,8 @@ function(add_unit_test_target name)
             rapidcheck
             rapidcheck_gtest
             rapidcheck_gmock)
-        target_link_libraries(${name} PRIVATE sanitizer-exceptions)
+        target_link_libraries(
+            ${name} PRIVATE ${INFRA_TARGET_NAMESPACE}sanitizer-exceptions)
         if(UNIT_NORANDOM)
             message(
                 WARNING
@@ -209,10 +214,10 @@ function(add_unit_test_target name)
         COMMAND ${target_test_command}
         COMMAND ${CMAKE_COMMAND} "-E" "touch" "${name}.passed"
         DEPENDS ${name})
-    add_dependencies(cpp_tests "run_${name}")
+    add_dependencies(${INFRA_TARGET_NAMESPACE}cpp_tests "run_${name}")
 
     if(UNIT_COVERAGE)
-        target_link_libraries(${name} PRIVATE coverage)
+        target_link_libraries(${name} PRIVATE ${INFRA_TARGET_NAMESPACE}coverage)
         add_test_coverage_target(${name})
     endif()
 endfunction()
@@ -279,7 +284,7 @@ function(add_python_test_target name)
                 ${auto_dependencies}
         COMMAND_EXPAND_LISTS)
 
-    add_dependencies(python_tests "run_${name}")
+    add_dependencies(${INFRA_TARGET_NAMESPACE}python_tests "run_${name}")
 endfunction()
 
 function(detect_test_framework)
@@ -328,8 +333,8 @@ function(add_feature_test_target name)
     target_include_directories(${name} PRIVATE ${FEAT_INCLUDE_DIRECTORIES})
     target_link_libraries(${name} PRIVATE ${FEAT_LIBRARIES})
     target_link_libraries_system(${name} PRIVATE ${FEAT_SYSTEM_LIBRARIES})
-    target_link_libraries(${name} PRIVATE sanitizers)
-    add_dependencies(build_unit_tests ${name})
+    target_link_libraries(${name} PRIVATE ${INFRA_TARGET_NAMESPACE}sanitizers)
+    add_dependencies(${INFRA_TARGET_NAMESPACE}build_unit_tests ${name})
 
     target_include_directories(
         ${name} SYSTEM
@@ -368,10 +373,10 @@ function(add_feature_test_target name)
         DEPENDS ${name})
 
     set_property(TEST ${name} PROPERTY ENVIRONMENT "SCENARIO=${FEATURE_FILE}")
-    add_dependencies(cpp_tests "run_${name}")
+    add_dependencies(${INFRA_TARGET_NAMESPACE}cpp_tests "run_${name}")
 
     if(UNIT_COVERAGE)
-        target_link_libraries(${name} PRIVATE coverage)
+        target_link_libraries(${name} PRIVATE ${INFRA_TARGET_NAMESPACE}coverage)
         add_test_coverage_target(${name})
     endif()
 endfunction()
@@ -393,7 +398,7 @@ function(add_fuzz_test_target name)
     target_include_directories(${name} PRIVATE ${FUZZ_INCLUDE_DIRECTORIES})
     target_link_libraries(${name} PRIVATE ${FUZZ_LIBRARIES})
     target_link_libraries_system(${name} PRIVATE ${FUZZ_SYSTEM_LIBRARIES})
-    add_dependencies(build_unit_tests ${name})
+    add_dependencies(${INFRA_TARGET_NAMESPACE}build_unit_tests ${name})
 
     target_compile_definitions(
         ${name} PRIVATE FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
@@ -437,10 +442,10 @@ function(add_fuzz_test_target name)
         COMMAND ${CMAKE_COMMAND} "-E" "touch" "${name}.passed"
         DEPENDS ${name})
 
-    add_dependencies(cpp_tests "run_${name}")
+    add_dependencies(${INFRA_TARGET_NAMESPACE}cpp_tests "run_${name}")
 
     if(UNIT_COVERAGE)
-        target_link_libraries(${name} PRIVATE coverage)
+        target_link_libraries(${name} PRIVATE ${INFRA_TARGET_NAMESPACE}coverage)
         add_test_coverage_target(${name})
     endif()
 endfunction()

--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -1,7 +1,7 @@
-add_library(warnings INTERFACE)
+add_library(${INFRA_TARGET_NAMESPACE}warnings INTERFACE)
 
 target_compile_options(
-    warnings
+    ${INFRA_TARGET_NAMESPACE}warnings
     INTERFACE
         # warnings turned on
         -Wall

--- a/docs/intro.adoc
+++ b/docs/intro.adoc
@@ -58,3 +58,17 @@ Auto-updates will not occur in the following circumstances:
 - `INFRA_SELF_UPDATE` is `OFF`
 - This repository is not fetched with CPM
 - You're using a filesystem copy rather than from a remote repository
+
+=== Generated targets
+
+Using the code in this repository causes targets to be generated, and it is
+possible those targets may clash with other targets from outside this
+repository. To avoid clashing targets, set the CMake variable
+`INFRA_TARGET_NAMESPACE` before including this code.
+
+[source,bash]
+----
+$ cmake -Bbuild -DINFRA_TARGET_NAMESPACE=infra
+...
+$ ninja -C build infra.unit_tests
+----

--- a/test/application/test/CMakeLists.txt
+++ b/test/application/test/CMakeLists.txt
@@ -5,8 +5,8 @@ add_unit_test(
     FILES
     catch2_test.cpp
     LIBRARIES
-    diagnostics
-    warnings)
+    ${INFRA_TARGET_NAMESPACE}diagnostics
+    ${INFRA_TARGET_NAMESPACE}warnings)
 add_mull_test(catch2_test EXCLUDE_CTEST RUNNER_ARGS --allow-surviving)
 
 add_unit_test(
@@ -16,8 +16,8 @@ add_unit_test(
     FILES
     gtest_test.cpp
     LIBRARIES
-    diagnostics
-    warnings)
+    ${INFRA_TARGET_NAMESPACE}diagnostics
+    ${INFRA_TARGET_NAMESPACE}warnings)
 
 add_unit_test(
     gunit_test
@@ -26,8 +26,8 @@ add_unit_test(
     FILES
     gunit_test.cpp
     LIBRARIES
-    diagnostics
-    warnings)
+    ${INFRA_TARGET_NAMESPACE}diagnostics
+    ${INFRA_TARGET_NAMESPACE}warnings)
 target_compile_features(gunit_test PRIVATE cxx_std_17)
 
 add_unit_test(
@@ -37,8 +37,8 @@ add_unit_test(
     FILES
     snitch_test.cpp
     LIBRARIES
-    diagnostics
-    warnings)
+    ${INFRA_TARGET_NAMESPACE}diagnostics
+    ${INFRA_TARGET_NAMESPACE}warnings)
 
 add_unit_test(
     custom_test
@@ -46,8 +46,8 @@ add_unit_test(
     FILES
     custom_test.cpp
     LIBRARIES
-    diagnostics
-    warnings)
+    ${INFRA_TARGET_NAMESPACE}diagnostics
+    ${INFRA_TARGET_NAMESPACE}warnings)
 
 add_feature_test(
     gunit_feature_test
@@ -57,8 +57,8 @@ add_feature_test(
     FEATURE
     test.feature
     LIBRARIES
-    diagnostics
-    warnings)
+    ${INFRA_TARGET_NAMESPACE}diagnostics
+    ${INFRA_TARGET_NAMESPACE}warnings)
 
 add_fuzz_test(
     fuzz_test
@@ -66,12 +66,15 @@ add_fuzz_test(
     FILES
     fuzz_test.cpp
     LIBRARIES
-    diagnostics
-    warnings)
+    ${INFRA_TARGET_NAMESPACE}diagnostics
+    ${INFRA_TARGET_NAMESPACE}warnings)
 
-add_compile_fail_test(compile_fail_test.cpp LIBRARIES diagnostics warnings)
-add_compile_fail_test(compile_fail_test_no_pattern.cpp LIBRARIES diagnostics
-                      warnings)
+add_compile_fail_test(
+    compile_fail_test.cpp LIBRARIES ${INFRA_TARGET_NAMESPACE}diagnostics
+    ${INFRA_TARGET_NAMESPACE}warnings)
+add_compile_fail_test(
+    compile_fail_test_no_pattern.cpp LIBRARIES
+    ${INFRA_TARGET_NAMESPACE}diagnostics ${INFRA_TARGET_NAMESPACE}warnings)
 
 add_unit_test(
     nonrandom_test
@@ -81,8 +84,8 @@ add_unit_test(
     FILES
     nonrandom_test.cpp
     LIBRARIES
-    diagnostics
-    warnings)
+    ${INFRA_TARGET_NAMESPACE}diagnostics
+    ${INFRA_TARGET_NAMESPACE}warnings)
 
 add_unit_test(pytest_test PYTEST FILES pytest_test.py EXTRA_ARGS --pass)
 mypy_lint(FILES pytest_test.py)
@@ -93,5 +96,5 @@ add_benchmark(
     FILES
     nanobm_test.cpp
     LIBRARIES
-    diagnostics
-    warnings)
+    ${INFRA_TARGET_NAMESPACE}diagnostics
+    ${INFRA_TARGET_NAMESPACE}warnings)


### PR DESCRIPTION
Problem:
- Infrastructure generates many targets which may clash with user targets.

Solution:
- Allow a target prefix namespace be specified with INFRA_TARGET_NAMESPACE.

Note:
- Test targets are already user-defined, so are not given the prefix. But all the top-level rollup targets and internal targets are.