### PR TITLE
:bug: :construction_worker: Restore clang-20 to build matrix

### DIFF
--- a/ci/.github/workflows/unit_tests.yml
+++ b/ci/.github/workflows/unit_tests.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         compiler: [clang, gcc]
-        version: [12, 13, 14, 16, 17, 18, 19, 21]
+        version: [12, 13, 14, 16, 17, 18, 19, 20, 21]
         cxx_standard: [20]
         stdlib: [libstdc++, libc++]
         build_type: [Debug]


### PR DESCRIPTION
Problem:
- Clang 20 was accidentally removed from the build matrix.

Solution:
- Add it back.