### PR TITLE
:sparkles: Add `-Wnrvo` to warnings

### DIFF
--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -22,12 +22,14 @@ target_compile_options(
         $<$<CXX_COMPILER_ID:Clang>:-Widiomatic-parentheses>
         $<$<CXX_COMPILER_ID:Clang>:-Wimplicit-fallthrough>
         $<$<CXX_COMPILER_ID:GNU>:-Wlogical-op>
+        $<$<CXX_COMPILER_ID:Clang>:-Wmissing-prototypes>
         $<$<CXX_COMPILER_ID:Clang>:-Wnewline-eof>
+        $<$<AND:$<CXX_COMPILER_ID:Clang>,$<VERSION_GREATER_EQUAL:${CMAKE_CXX_COMPILER_VERSION},21>>:-Wnrvo>
+        $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_GREATER_EQUAL:${CMAKE_CXX_COMPILER_VERSION},14>>:-Wnrvo>
         -Wold-style-cast
         -Woverloaded-virtual
         $<$<CXX_COMPILER_ID:Clang>:-Wpedantic>
         -Wshadow
         $<$<CXX_COMPILER_ID:Clang>:-Wshift-sign-overflow>
         $<$<CXX_COMPILER_ID:GNU>:-Wuseless-cast>
-        -Wunused
-        $<$<CXX_COMPILER_ID:Clang>:-Wmissing-prototypes>)
+        -Wunused)


### PR DESCRIPTION
Problem:
- We want to be sure we are getting named RVO (move elision) when we want it.
- Clang and GCC both have issues with NRVO in some cases

Solution:
- Enable `-Wnrvo` (clang 21+, GCC 14+)
   - https://releases.llvm.org/21.1.0/tools/clang/docs/DiagnosticsReference.html#wnrvo
   - https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wnrvo