### PR TITLE
:construction_worker: :books: Add mermaid diagrams to docs deps

### DIFF
--- a/.github/workflows/asciidoctor-ghpages.yml
+++ b/.github/workflows/asciidoctor-ghpages.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install Mermaid
         run: |
-          npm install -g @mermaid-js/mermaid-cli@11.4.2
+          npm install -g @mermaid-js/mermaid-cli@11.12.0
           npx puppeteer browsers install chrome-headless-shell
 
       - name: Install asciidoctor

--- a/ci/.github/workflows/asciidoctor-ghpages.yml
+++ b/ci/.github/workflows/asciidoctor-ghpages.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install Mermaid
         run: |
-          npm install -g @mermaid-js/mermaid-cli@11.4.2
+          npm install -g @mermaid-js/mermaid-cli@11.12.0
           npx puppeteer browsers install chrome-headless-shell
 
       - name: Install asciidoctor

--- a/cmake/docs.cmake
+++ b/cmake/docs.cmake
@@ -56,13 +56,14 @@ function(add_docs DIRECTORY)
     endif()
 
     file(GLOB_RECURSE doc_files ${CMAKE_SOURCE_DIR}/${rel_dir}/*.adoc)
+    file(GLOB_RECURSE mmd_files ${CMAKE_SOURCE_DIR}/${rel_dir}/*.mmd)
     add_custom_command(
         OUTPUT ${CMAKE_BINARY_DIR}/${rel_dir}/index.html
         COMMAND
             ${ASCIIDOCTOR_PROGRAM} -r asciidoctor-diagram
             ${CMAKE_SOURCE_DIR}/${rel_dir}/index.adoc -D
             ${CMAKE_BINARY_DIR}/${rel_dir}
-        DEPENDS ${doc_files})
+        DEPENDS ${doc_files} ${mmd_files})
     add_dependencies(${INFRA_TARGET_NAMESPACE}docs
                      ${INFRA_TARGET_NAMESPACE}docs_${target})
 endfunction()


### PR DESCRIPTION
Problem:
- When `.mmd` files are included in documentation, cmake does not discover them as dependencies.

Solution:
- Discover `*.mmd` files as documentation dependencies.