### PR TITLE
:art: Streamline Asciidoctor installation steps

### DIFF
--- a/.github/workflows/asciidoctor-ghpages.yml
+++ b/.github/workflows/asciidoctor-ghpages.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install Mermaid
         run: |

--- a/.github/workflows/asciidoctor-ghpages.yml
+++ b/.github/workflows/asciidoctor-ghpages.yml
@@ -40,15 +40,10 @@ jobs:
         with:
           node-version: 22
 
-      - name: Install Mermaid
+      - name: Install Asciidoctor & Mermaid
         run: |
           npm install -g @mermaid-js/mermaid-cli@11.12.0
           npx puppeteer browsers install chrome-headless-shell
-
-      - name: Install asciidoctor
-        run: |
-          sudo apt update
-          sudo apt install -y asciidoctor
           sudo gem install asciidoctor asciidoctor-diagram rouge
 
       - name: Restore CPM cache

--- a/ci/.github/workflows/asciidoctor-ghpages.yml
+++ b/ci/.github/workflows/asciidoctor-ghpages.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install Mermaid
         run: |

--- a/ci/.github/workflows/asciidoctor-ghpages.yml
+++ b/ci/.github/workflows/asciidoctor-ghpages.yml
@@ -40,15 +40,10 @@ jobs:
         with:
           node-version: 22
 
-      - name: Install Mermaid
+      - name: Install Asciidoctor & Mermaid
         run: |
           npm install -g @mermaid-js/mermaid-cli@11.12.0
           npx puppeteer browsers install chrome-headless-shell
-
-      - name: Install asciidoctor
-        run: |
-          sudo apt update
-          sudo apt install -y asciidoctor
           sudo gem install asciidoctor asciidoctor-diagram rouge
 
       - name: Restore CPM cache


### PR DESCRIPTION
Problem:
- Asciidoctor installation step uses apt superfluously; since we are installing Asciidoctor using its ruby gem, there is no need to install it first using apt.

Solution:
- Remove apt from Asciidoctor installation step.
- Coalesce Asciidoctor and Mermaid installation steps.