### PR TITLE
:art: Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,15 @@
-build/
+# ignore all directories that start with .
+**/.*/
+
+# ignore conventionally-named build directories
+**/build*/
+**/*build/
+# and some other build directories
+**/cmake-build-*/
+
+# ignore conventionally-named Python virtual env directories
+# (this is only necessary before Python 3.13)
+**/venv*/
+**/*venv/
+# and __pycache__ directories
+**/__pycache__/

--- a/cmake/setup.cmake
+++ b/cmake/setup.cmake
@@ -4,13 +4,13 @@ endif()
 
 function(make_gitignore)
     set(GITIGNORE_CONTENTS
-        "build/"
-        "/cmake-build-*"
-        "/venv"
-        "/.vscode"
-        "/.idea"
-        "/.cache"
-        "/.DS_Store")
+        "**/.*/"
+        "**/build*/"
+        "**/*build/"
+        "**/cmake-build-*/"
+        "**/venv*/"
+        "**/*venv/"
+        "**/__pycache__/")
 
     if(INFRA_USE_SYMLINKS)
         if(INFRA_PROVIDE_CLANG_FORMAT)


### PR DESCRIPTION
Problem:
- Cache directories made by various tools can be made in any directory, but are only ignored in the root directory.
- Conventional directory names containing "build" or "venv" should be ignored.

Solution:
- Alter .gitignore to properly ignore cache directories and conventionally-named venv/build directories.