### PR TITLE
:art: Adjust clang-format to reflect CIB better

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,7 +5,7 @@ IncludeBlocks: Regroup
 IncludeCategories:
   - Regex: '^".*'
     Priority: 1
-  - Regex: '^<(container|cib|flow|interrupt|log|lookup|match|msg|safe|sc|seq)/.*'
+  - Regex: '^<(cib|flow|interrupt|log|log_binary|log_fmt|lookup|match|msg|nexus|seq)/.*'
     Priority: 2
   - Regex: '^<groov/.*'
     Priority: 4


### PR DESCRIPTION
Problem:
- The `.clang-format` file contains some old library paths (container, safe, sc) and does not contain `nexus`, `log_fmt` or `log_binary`, which are current CIB libraries.

Solution:
- Adjust `.clang-format` include categories.

Note:
- At the moment the `cib` library and the `cib_nexus` library both share the `cib/` include path; this change allows them to be split.
- At the moment the `log`, `log_binary` and `log_fmt` librares share the `log/` include path; this change allows them to be split.