### PR TITLE
:art: Remove BUILD_TESTING tinkering

### DIFF
--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -1,5 +1,3 @@
-option(BUILD_TESTING "" OFF)
-include(CTest)
 add_custom_target(${INFRA_TARGET_NAMESPACE}unit_tests)
 add_custom_target(${INFRA_TARGET_NAMESPACE}cpp_tests)
 add_custom_target(${INFRA_TARGET_NAMESPACE}python_tests)
@@ -7,10 +5,6 @@ add_custom_target(${INFRA_TARGET_NAMESPACE}build_unit_tests)
 add_dependencies(
     ${INFRA_TARGET_NAMESPACE}unit_tests ${INFRA_TARGET_NAMESPACE}cpp_tests
     ${INFRA_TARGET_NAMESPACE}python_tests)
-
-set(CMAKE_TESTING_ENABLED
-    1
-    CACHE INTERNAL "")
 
 find_program(MEMORYCHECK_COMMAND NAMES valgrind)
 set(MEMORYCHECK_SUPPRESSIONS_FILE
@@ -93,9 +87,12 @@ endmacro()
 
 macro(add_gherkin)
     if(NOT TARGET gherkin-cpp)
+        block(SCOPE_FOR VARIABLES)
+        set(BUILD_TESTING OFF)
         add_subdirectory(
             ${gunit_SOURCE_DIR}/libs/gherkin-cpp
             ${gunit_BINARY_DIR}/libs/gherkin-cpp EXCLUDE_FROM_ALL SYSTEM)
+        endblock()
     endif()
 endmacro()
 

--- a/test/application/CMakeLists.txt
+++ b/test/application/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(test_app)
 
 include(cmake/get_cpm.cmake)
@@ -11,7 +11,8 @@ add_versioned_package(NAME test_lib SOURCE_DIR
 add_executable(test_app src/test.cpp)
 target_link_libraries(test_app PRIVATE test_lib)
 
-if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+if(PROJECT_IS_TOP_LEVEL)
+    include(CTest)
     add_subdirectory(test)
     add_subdirectory(recipes)
 endif()

--- a/test/application/recipes/CMakeLists.txt
+++ b/test/application/recipes/CMakeLists.txt
@@ -3,7 +3,7 @@ add_custom_target(recipe_tests)
 function(test_recipe NAME VERSION LIBNAME)
     cmake_language(CALL ${NAME}_recipe ${VERSION})
     add_executable(${NAME}_recipe_app ${NAME}_recipe.cpp)
-    target_link_libraries(${NAME}_recipe_app PRIVATE ${LIBNAME})
+    target_link_libraries_system(${NAME}_recipe_app PRIVATE ${LIBNAME})
     add_dependencies(recipe_tests ${NAME}_recipe_app)
 endfunction()
 

--- a/test/library/CMakeLists.txt
+++ b/test/library/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(test_lib)
 
 include(cmake/get_cpm.cmake)
@@ -29,8 +29,9 @@ target_sources(
               include/test_lib/exclude.hpp
               include/exclude/bad.hpp)
 
-if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+if(PROJECT_IS_TOP_LEVEL)
     add_docs(docs)
     clang_tidy_interface(TARGET test_lib EXCLUDE_FILESETS exclusions)
+    include(CTest)
     add_subdirectory(test)
 endif()


### PR DESCRIPTION
Problem:
- Manually setting `CMAKE_TESTING_ENABLED` is not necessary; `include(CTest)` does that, while respecting the `BUILD_TESTING` option.

Solution:
- Remove the manual code.