### PR TITLE
:arrow_up: Update to add C++23 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Where `abc123` is the version of this repository you want to depend on.
 This repository depends on:
 
 - [Boost-ext.DI](https://github.com/boost-ext/di) at version 1.3.2
-- [Catch2](https://github.com/catchorg/Catch2) at version 3.8.0
+- [Catch2](https://github.com/catchorg/Catch2) at version 3.12.0
 - [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake) at version 0.40.2
-- [fuzztest](https://github.com/google/fuzztest) at git hash a4f6ad5
+- [fuzztest](https://github.com/google/fuzztest) at git hash d7e0165 (2025-08-05)
 - [GoogleTest](https://github.com/google/googletest) at version 1.16.0
 - [GUnit](https://github.com/cpp-testing/GUnit) at version 1.16.0
 - [metabench](https://github.com/ldionne/metabench) at git hash 3322ce7

--- a/cmake/coverage.cmake
+++ b/cmake/coverage.cmake
@@ -68,7 +68,8 @@ function(add_test_coverage_target name)
         add_custom_command(
             OUTPUT coverage/${name}.profraw
             COMMAND env "LLVM_PROFILE_FILE=coverage/${name}.profraw"
-                    $<TARGET_FILE:${name}>
+                    $<TARGET_FILE:${name}> ${ARGN}
+            COMMAND_EXPAND_LISTS
             DEPENDS run_${name})
         add_custom_target(${INFRA_TARGET_NAMESPACE}raw_coverage_${name}
                           DEPENDS coverage/${name}.profraw)

--- a/cmake/main.cmake
+++ b/cmake/main.cmake
@@ -11,12 +11,6 @@ else()
     file(WRITE ${PROJECT_BINARY_DIR}/.gitignore "*")
 endif()
 
-if(NOT DEFINED CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD
-        20
-        CACHE INTERNAL "" FORCE)
-endif()
-
 set(CMAKE_EXPORT_COMPILE_COMMANDS
     ON
     CACHE BOOL "Export compile commands to compile_commands.json." FORCE)

--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -22,7 +22,7 @@ target_compile_options(${INFRA_TARGET_NAMESPACE}sanitizer-exceptions
 
 macro(get_catch2)
     if(NOT TARGET Catch2::Catch2WithMain)
-        add_versioned_package("gh:catchorg/Catch2@3.8.0")
+        add_versioned_package("gh:catchorg/Catch2@3.12.0")
         list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras)
         include(Catch)
 
@@ -70,7 +70,7 @@ macro(get_fuzztest)
             NAME
             fuzztest
             GIT_TAG
-            a4f6ad5
+            d7e0165
             GITHUB_REPOSITORY
             google/fuzztest
             OPTIONS
@@ -109,6 +109,15 @@ macro(add_rapidcheck)
         add_subdirectory(
             ${rapidcheck_SOURCE_DIR}/extras/gmock
             ${rapidcheck_BINARY_DIR}/extras/gmock EXCLUDE_FROM_ALL SYSTEM)
+
+        # Workaround for rapidcheck's use of aligned_storage
+        add_library(${INFRA_TARGET_NAMESPACE}clean-rapidcheck-warnings
+                    INTERFACE)
+        target_compile_options(
+            ${INFRA_TARGET_NAMESPACE}clean-rapidcheck-warnings
+            INTERFACE
+                $<$<VERSION_GREATER_EQUAL:${CMAKE_CXX_STANDARD},23>:-Wno-deprecated-declarations>
+        )
     endif()
 endmacro()
 
@@ -119,8 +128,6 @@ function(add_unit_test_target name)
 
     add_executable(${name} ${UNIT_FILES})
     target_include_directories(${name} PRIVATE ${UNIT_INCLUDE_DIRECTORIES})
-    target_link_libraries(${name} PRIVATE ${UNIT_LIBRARIES})
-    target_link_libraries_system(${name} PRIVATE ${UNIT_SYSTEM_LIBRARIES})
     target_link_libraries(${name} PRIVATE ${INFRA_TARGET_NAMESPACE}sanitizers)
     add_dependencies(${INFRA_TARGET_NAMESPACE}build_unit_tests ${name})
 
@@ -132,18 +139,21 @@ function(add_unit_test_target name)
                 WARNING
                     "${name} is set to NORANDOM: unrandomized tests are not best practice"
             )
-            set(target_test_command $<TARGET_FILE:${name}>)
-            add_test(NAME ${name} COMMAND ${target_test_command})
+            set(test_args "--order" "decl")
+            add_test(NAME ${name} COMMAND $<TARGET_FILE:${name}> ${test_args}
+                                          COMMAND_EXPAND_LISTS)
         else()
-            set(target_test_command $<TARGET_FILE:${name}> "--order" "rand")
             if(DEFINED ENV{CI})
-                add_test(NAME ${name} COMMAND ${target_test_command})
+                add_test(NAME ${name} COMMAND $<TARGET_FILE:${name}>
+                                              ${test_args} COMMAND_EXPAND_LISTS)
             else()
                 catch_discover_tests(${name})
             endif()
         endif()
         target_link_libraries(
             ${name} PRIVATE ${INFRA_TARGET_NAMESPACE}clean-catch2-warnings)
+        target_link_libraries(
+            ${name} PRIVATE ${INFRA_TARGET_NAMESPACE}clean-rapidcheck-warnings)
     elseif(UNIT_GTEST)
         target_link_libraries_system(
             ${name}
@@ -159,16 +169,19 @@ function(add_unit_test_target name)
                 WARNING
                     "${name} is set to NORANDOM: unrandomized tests are not best practice"
             )
-            set(target_test_command $<TARGET_FILE:${name}>)
-            add_test(NAME ${name} COMMAND ${target_test_command})
+            add_test(NAME ${name} COMMAND $<TARGET_FILE:${name}> ${test_args}
+                                          COMMAND_EXPAND_LISTS)
         else()
-            set(target_test_command $<TARGET_FILE:${name}> "--gtest_shuffle")
+            set(test_args "--gtest_shuffle")
             if(DEFINED ENV{CI})
-                add_test(NAME ${name} COMMAND ${target_test_command})
+                add_test(NAME ${name} COMMAND $<TARGET_FILE:${name}>
+                                              ${test_args} COMMAND_EXPAND_LISTS)
             else()
                 gtest_discover_tests(${name})
             endif()
         endif()
+        target_link_libraries(
+            ${name} PRIVATE ${INFRA_TARGET_NAMESPACE}clean-rapidcheck-warnings)
     elseif(UNIT_GUNIT)
         target_include_directories(
             ${name} SYSTEM
@@ -190,32 +203,37 @@ function(add_unit_test_target name)
                 WARNING
                     "${name} is set to NORANDOM: unrandomized tests are not best practice"
             )
-            set(target_test_command $<TARGET_FILE:${name}>)
         else()
-            set(target_test_command $<TARGET_FILE:${name}> "--gtest_shuffle")
+            set(test_args "--gtest_shuffle")
         endif()
-        add_test(NAME ${name} COMMAND ${target_test_command})
+        add_test(NAME ${name} COMMAND $<TARGET_FILE:${name}> ${test_args}
+                                      COMMAND_EXPAND_LISTS)
+        target_link_libraries(
+            ${name} PRIVATE ${INFRA_TARGET_NAMESPACE}clean-rapidcheck-warnings)
     elseif(UNIT_SNITCH)
         target_link_libraries_system(${name} PRIVATE snitch::snitch)
-        set(target_test_command $<TARGET_FILE:${name}>)
-        add_test(NAME ${name} COMMAND ${target_test_command})
+        add_test(NAME ${name} COMMAND $<TARGET_FILE:${name}> ${test_args}
+                                      COMMAND_EXPAND_LISTS)
     else()
-        set(target_test_command $<TARGET_FILE:${name}>)
-        add_test(NAME ${name} COMMAND ${target_test_command})
+        add_test(NAME ${name} COMMAND $<TARGET_FILE:${name}> ${test_args}
+                                      COMMAND_EXPAND_LISTS)
     endif()
+
+    target_link_libraries(${name} PRIVATE ${UNIT_LIBRARIES})
+    target_link_libraries_system(${name} PRIVATE ${UNIT_SYSTEM_LIBRARIES})
 
     add_custom_target(all_${name} ALL DEPENDS run_${name})
     add_custom_target(run_${name} DEPENDS ${name}.passed)
     add_custom_command(
         OUTPUT ${name}.passed
-        COMMAND ${target_test_command}
+        COMMAND $<TARGET_FILE:${name}> ${test_args}
         COMMAND ${CMAKE_COMMAND} "-E" "touch" "${name}.passed"
         DEPENDS ${name})
     add_dependencies(${INFRA_TARGET_NAMESPACE}cpp_tests "run_${name}")
 
     if(UNIT_COVERAGE)
         target_link_libraries(${name} PRIVATE ${INFRA_TARGET_NAMESPACE}coverage)
-        add_test_coverage_target(${name})
+        add_test_coverage_target(${name} ${test_args})
     endif()
 endfunction()
 

--- a/test/application/CMakeLists.txt
+++ b/test/application/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.21)
 project(test_app)
 
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 23)
+endif()
+
 include(cmake/get_cpm.cmake)
 cpmaddpackage(NAME infra SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." GIT_TAG
               HEAD)

--- a/test/library/CMakeLists.txt
+++ b/test/library/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.21)
 project(test_lib)
 
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 23)
+endif()
+
 include(cmake/get_cpm.cmake)
 cpmaddpackage(NAME infra SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." GIT_TAG
               HEAD)


### PR DESCRIPTION
Problem:
- The CICD repo sets the C++ standard; that should only be set by top-level
  CMakeLists.txt or on the cmake command line.
- Some dependencies don't play nicely with C++23.

Solution:
- Remove code setting the C++ standard.
- Update Catch2 and fuzztest frameworks.
- Update tests to C++23. Work around framework warnings.

Note:
- Catch2 changed to randomize tests by default (with no command-line options).
  So in order to run `NORANDOM` tests successfully we need to supply
  command-line options in every place -- not just the test itself, but also the
  coverage target which runs the test.