### PR TITLE
:arrow_up: Updates: mull, clang-22, warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,9 @@ env:
   DEBIAN_FRONTEND: noninteractive
   CMAKE_GENERATOR: Ninja
   TARGET_LLVM_VERSION: 21
-  MULL_LLVM_MAJOR_VERSION: 19
-  MULL_LLVM_VERSION: 19.1.1
-  MULL_VERSION: 0.27.1
+  MULL_LLVM_MAJOR_VERSION: 20
+  MULL_LLVM_VERSION: 20.1.2
+  MULL_VERSION: 0.29.0
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -225,8 +225,9 @@ jobs:
         env:
           mull-pkg: Mull-${{env.MULL_LLVM_MAJOR_VERSION}}-${{env.MULL_VERSION}}-LLVM-${{env.MULL_LLVM_VERSION}}-ubuntu-amd64-24.04.deb
         run: |
-          wget https://github.com/mull-project/mull/releases/download/${{env.MULL_VERSION}}/${{env.mull-pkg}}
-          sudo dpkg -i ${{env.mull-pkg}}
+          MULL_DEB="$(mktemp)"
+          wget -O "$MULL_DEB" https://github.com/mull-project/mull/releases/download/${{env.MULL_VERSION}}/${{env.mull-pkg}}
+          sudo dpkg -i "$MULL_DEB"
 
       - name: Checkout PR branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ on:
 env:
   DEBIAN_FRONTEND: noninteractive
   CMAKE_GENERATOR: Ninja
-  TARGET_LLVM_VERSION: 21
+  TARGET_LLVM_VERSION: 22
   MULL_LLVM_MAJOR_VERSION: 20
   MULL_LLVM_VERSION: 20.1.2
   MULL_VERSION: 0.29.0
@@ -33,8 +33,10 @@ jobs:
     steps:
       - name: Install build tools
         run: |
-          sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" llvm.sh ${{env.TARGET_LLVM_VERSION}}
-          sudo apt update && sudo apt install -y pip ninja-build clang-tidy-${{env.TARGET_LLVM_VERSION}} clang-format-${{env.TARGET_LLVM_VERSION}}
+          export DISTRO=$(lsb_release -cs)
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+          sudo add-apt-repository -y deb https://apt.llvm.org/$DISTRO/ llvm-toolchain-$DISTRO-${{env.TARGET_LLVM_VERSION}} main
+          sudo apt update && sudo apt install -y pip ninja-build clang-${{env.TARGET_LLVM_VERSION}} clang-tidy-${{env.TARGET_LLVM_VERSION}} clang-format-${{env.TARGET_LLVM_VERSION}}
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -171,8 +173,10 @@ jobs:
 
       - name: Install build tools
         run: |
-          wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh ${{env.TARGET_LLVM_VERSION}}
-          sudo apt install -y ninja-build clang-tidy-${{env.TARGET_LLVM_VERSION}} clang-format-${{env.TARGET_LLVM_VERSION}}
+          export DISTRO=$(lsb_release -cs)
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+          sudo add-apt-repository -y deb https://apt.llvm.org/$DISTRO/ llvm-toolchain-$DISTRO-${{env.TARGET_LLVM_VERSION}} main
+          sudo apt install -y ninja-build clang-${{env.TARGET_LLVM_VERSION}} clang-tidy-${{env.TARGET_LLVM_VERSION}} clang-format-${{env.TARGET_LLVM_VERSION}}
 
       - name: Restore CPM cache
         env:
@@ -218,8 +222,10 @@ jobs:
     steps:
       - name: Install build tools
         run: |
-          wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh ${{env.MULL_LLVM_MAJOR_VERSION}}
-          sudo apt install -y ninja-build
+          export DISTRO=$(lsb_release -cs)
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+          sudo add-apt-repository -y deb https://apt.llvm.org/$DISTRO/ llvm-toolchain-$DISTRO-${{env.TARGET_LLVM_VERSION}} main
+          sudo apt install -y ninja-build clang-${{env.MULL_LLVM_MAJOR_VERSION}}
 
       - name: Install mull
         env:

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -143,6 +143,9 @@ function(log_dependency_trail parent child depth)
 endfunction()
 
 function(add_versioned_package)
+    set(WARNINGS_AS_ERRORS ${CMAKE_COMPILE_WARNING_AS_ERROR})
+    set(CMAKE_COMPILE_WARNING_AS_ERROR OFF)
+
     list(LENGTH ARGN argnLength)
     if(argnLength EQUAL 1)
         cpm_parse_add_package_single_arg("${ARGN}" ARGN)
@@ -183,6 +186,8 @@ function(add_versioned_package)
     set(${CPM_LAST_PACKAGE_NAME}_ADDED
         ${${CPM_LAST_PACKAGE_NAME}_ADDED}
         PARENT_SCOPE)
+
+    set(CMAKE_COMPILE_WARNING_AS_ERROR ${WARNINGS_AS_ERRORS})
 endfunction()
 
 function(update_versioned_package)

--- a/cmake/main.cmake
+++ b/cmake/main.cmake
@@ -13,7 +13,10 @@ endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS
     ON
-    CACHE BOOL "Export compile commands to compile_commands.json." FORCE)
+    CACHE BOOL "Export compile commands to compile_commands.json.")
+set(CMAKE_COMPILE_WARNING_AS_ERROR
+    ON
+    CACHE BOOL "Treat warnings as errors.")
 
 option(INFRA_PROVIDE_GITHUB_WORKFLOWS
        "Provide unit_test and documentation workflows" ON)

--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -88,6 +88,7 @@ endmacro()
 macro(add_gherkin)
     if(NOT TARGET gherkin-cpp)
         block(SCOPE_FOR VARIABLES)
+        set(CMAKE_COMPILE_WARNING_AS_ERROR OFF)
         set(BUILD_TESTING OFF)
         add_subdirectory(
             ${gunit_SOURCE_DIR}/libs/gherkin-cpp
@@ -98,6 +99,8 @@ endmacro()
 
 macro(add_rapidcheck)
     if(NOT TARGET rapidcheck)
+        block(SCOPE_FOR VARIABLES)
+        set(CMAKE_COMPILE_WARNING_AS_ERROR OFF)
         add_versioned_package(NAME rapidcheck GIT_TAG ff6af6f GITHUB_REPOSITORY
                               emil-e/rapidcheck)
         add_subdirectory(
@@ -118,6 +121,7 @@ macro(add_rapidcheck)
             INTERFACE
                 $<$<VERSION_GREATER_EQUAL:${CMAKE_CXX_STANDARD},23>:-Wno-deprecated-declarations>
         )
+        endblock()
     endif()
 endmacro()
 

--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -1,3 +1,20 @@
+add_library(${INFRA_TARGET_NAMESPACE}no-extension-warnings INTERFACE)
+
+target_compile_options(
+    ${INFRA_TARGET_NAMESPACE}no-extension-warnings
+    INTERFACE
+        $<$<CXX_COMPILER_ID:Clang>:-Wno-c99-extensions>
+        $<$<CXX_COMPILER_ID:Clang>:-Wno-c11-extensions>
+        $<$<CXX_COMPILER_ID:Clang>:-Wno-c2x-extensions>
+        $<$<AND:$<CXX_COMPILER_ID:Clang>,$<VERSION_GREATER_EQUAL:${CMAKE_CXX_COMPILER_VERSION},19>>:-Wno-c2y-extensions>
+        $<$<CXX_COMPILER_ID:Clang>:-Wno-c++11-extensions>
+        $<$<CXX_COMPILER_ID:Clang>:-Wno-c++14-extensions>
+        $<$<CXX_COMPILER_ID:Clang>:-Wno-c++17-extensions>
+        $<$<CXX_COMPILER_ID:Clang>:-Wno-c++2a-extensions>
+        $<$<CXX_COMPILER_ID:Clang>:-Wno-c++2b-extensions>
+        $<$<AND:$<CXX_COMPILER_ID:Clang>,$<VERSION_GREATER_EQUAL:${CMAKE_CXX_COMPILER_VERSION},17>>:-Wno-c++26-extensions>
+)
+
 add_library(${INFRA_TARGET_NAMESPACE}warnings INTERFACE)
 
 target_compile_options(
@@ -22,7 +39,6 @@ target_compile_options(
         $<$<CXX_COMPILER_ID:Clang>:-Widiomatic-parentheses>
         $<$<CXX_COMPILER_ID:Clang>:-Wimplicit-fallthrough>
         $<$<CXX_COMPILER_ID:GNU>:-Wlogical-op>
-        $<$<CXX_COMPILER_ID:Clang>:-Wmissing-prototypes>
         $<$<CXX_COMPILER_ID:Clang>:-Wnewline-eof>
         $<$<AND:$<CXX_COMPILER_ID:Clang>,$<VERSION_GREATER_EQUAL:${CMAKE_CXX_COMPILER_VERSION},21>>:-Wnrvo>
         $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_GREATER_EQUAL:${CMAKE_CXX_COMPILER_VERSION},14>>:-Wnrvo>
@@ -33,3 +49,6 @@ target_compile_options(
         $<$<CXX_COMPILER_ID:Clang>:-Wshift-sign-overflow>
         $<$<CXX_COMPILER_ID:GNU>:-Wuseless-cast>
         -Wunused)
+
+target_link_libraries(${INFRA_TARGET_NAMESPACE}warnings
+                      INTERFACE ${INFRA_TARGET_NAMESPACE}no-extension-warnings)

--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -28,7 +28,6 @@ target_compile_options(
         -Wdouble-promotion
         $<$<CXX_COMPILER_ID:GNU>:-Wduplicated-branches>
         $<$<CXX_COMPILER_ID:GNU>:-Wduplicated-cond>
-        -Werror
         -Wextra
         -Wextra-semi
         $<$<AND:$<CXX_COMPILER_ID:Clang>,$<VERSION_GREATER_EQUAL:${CMAKE_CXX_COMPILER_VERSION},8>>:-Wextra-semi-stmt>


### PR DESCRIPTION
Problem:
- Mull has a new release that fixes some bugs.
- This repository uses LLVM 21; LLVM 22 is released and relatively stable.
- clang likes to backport useful extensions, but warns when you use them.
- `-Wmissing-prototypes` is just annoying and results in boilerplate.
- Not everybody wants to compile with warnings as errors, although it is a good default.

Solution:
- Update mull to 0.29.0.
- Upgrade to LLVM 22.
- Turn off clang warnings for extension use.
- Remove `-Wmissing-prototypes`.
- Remove `-Werror` and replace it with the cmake cache variable `CMAKE_COMPILE_WARNING_AS_ERROR`, allowing users to control it on the command line or in the cmake cache.

Note:
- `CMAKE_COMPILE_WARNING_AS_ERROR` is temporarily turned off around dependency
  additions.