### PR TITLE
:art: :rotating_light: Remove `readability-redundant-typename` clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -42,6 +42,7 @@ Checks: >
   -readability-named-parameter,
   -readability-qualified-auto,
   -readability-redundant-inline-specifier,
+  -readability-redundant-typename,
   -readability-uppercase-literal-suffix
 WarningsAsErrors: '*'
 HeaderFilterRegex: ''


### PR DESCRIPTION
Problem:
- C++23 removed the need to put typename in several places where a type must be the case (e.g. `using type_t = T:type_t`). When compiling with earlier versions this is still required, but clang-tidy warns about redundancy.

Solution:
- Remove the `readability-redundant-typename` tidy.