### PR TITLE
:bug: :construction_worker: Fix clang-tidy and compile commands

### DIFF
--- a/cmake/clang-tidy.cmake
+++ b/cmake/clang-tidy.cmake
@@ -133,17 +133,20 @@ function(clang_tidy_interface)
 endfunction()
 
 if(NOT TARGET ${INFRA_TARGET_NAMESPACE}clang-tidy-canary)
-    message(STATUS "Adding clang-tidy-canary target for ${CMAKE_SOURCE_DIR}")
-    add_custom_command(
-        OUTPUT clang_tidy_canary.alive
-        COMMAND ${CLANG_TIDY_PROGRAM} "--verify-config" 2>clang_tidy.log
-        COMMAND "!" "[" "-s" "clang_tidy.log" "]"
-        COMMAND ${CMAKE_COMMAND} "-E" "touch" "clang_tidy_canary.alive"
-        DEPENDS ${CMAKE_SOURCE_DIR}/.clang-tidy)
-    add_custom_target(${INFRA_TARGET_NAMESPACE}clang-tidy-canary
-                      DEPENDS clang_tidy_canary.alive)
-    add_dependencies(${INFRA_TARGET_NAMESPACE}clang-tidy
-                     ${INFRA_TARGET_NAMESPACE}clang-tidy-canary)
-    add_dependencies(${INFRA_TARGET_NAMESPACE}clang-tidy-branch-diff
-                     ${INFRA_TARGET_NAMESPACE}clang-tidy-canary)
+    if(${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL 22)
+        message(
+            STATUS "Adding clang-tidy-canary target for ${CMAKE_SOURCE_DIR}")
+        add_custom_command(
+            OUTPUT clang_tidy_canary.alive
+            COMMAND ${CLANG_TIDY_PROGRAM} "--verify-config" 2>clang_tidy.log
+            COMMAND "!" "[" "-s" "clang_tidy.log" "]"
+            COMMAND ${CMAKE_COMMAND} "-E" "touch" "clang_tidy_canary.alive"
+            DEPENDS ${CMAKE_SOURCE_DIR}/.clang-tidy)
+        add_custom_target(${INFRA_TARGET_NAMESPACE}clang-tidy-canary
+                          DEPENDS clang_tidy_canary.alive)
+        add_dependencies(${INFRA_TARGET_NAMESPACE}clang-tidy
+                         ${INFRA_TARGET_NAMESPACE}clang-tidy-canary)
+        add_dependencies(${INFRA_TARGET_NAMESPACE}clang-tidy-branch-diff
+                         ${INFRA_TARGET_NAMESPACE}clang-tidy-canary)
+    endif()
 endif()

--- a/cmake/main.cmake
+++ b/cmake/main.cmake
@@ -13,7 +13,7 @@ endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS
     ON
-    CACHE BOOL "Export compile commands to compile_commands.json.")
+    CACHE INTERNAL "Export compile commands to compile_commands.json.")
 set(CMAKE_COMPILE_WARNING_AS_ERROR
     ON
     CACHE BOOL "Treat warnings as errors.")


### PR DESCRIPTION
Problem:
- `CMAKE_EXPORT_COMPILE_COMMANDS` is an `INTERNAL` variable but it is being set as `BOOL`. This means it does not persist properly.
- `clang-tidy` has no mechanism to enable checks by version and fails to verify config if checks are unrecognized. This means we can't introduce new checks (or turn them off) easily.

Solution:
- Mark `CMAKE_EXPORT_COMPILE_COMMANDS` as `INTERNAL`.
- Run the clang-tidy canary only when running the latest supported clang toolchain.