### PR TITLE
:fire: Remove unnecessary sanitizer definitions

### DIFF
--- a/cmake/sanitizers.cmake
+++ b/cmake/sanitizers.cmake
@@ -16,13 +16,6 @@ if(SANITIZERS)
                                INTERFACE -fsanitize-memory-track-origins)
     endif()
 
-    string(REGEX MATCH "address|memory|thread" SANITIZER_NEW_DEL
-                 "${SANITIZERS}")
-    if(SANITIZER_NEW_DEL)
-        target_compile_definitions(${INFRA_TARGET_NAMESPACE}sanitizers
-                                   INTERFACE SANITIZER_NEW_DEL)
-    endif()
-
     target_link_options(${INFRA_TARGET_NAMESPACE}sanitizers INTERFACE
                         -fsanitize=${SANITIZERS})
 endif()


### PR DESCRIPTION
Problem:
- CICD defines `SANITIZER_NEW_DEL` when compiling with sanitizers; this is not needed for detection because toolchains define their own `__SANITIZER_*__` macros.

Solution:
- Remove the `SANITIZER_NEW_DEL` definition.