### PR TITLE
:bug: Don't force update a dependabot config

### DIFF
--- a/cmake/setup.cmake
+++ b/cmake/setup.cmake
@@ -172,6 +172,6 @@ if(PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
             "${CMAKE_SOURCE_DIR}/.github/workflows" FORCE)
         compare_and_update_file(
             dependabot.yml "${CMAKE_CURRENT_SOURCE_DIR}/ci/.github"
-            "${CMAKE_SOURCE_DIR}/.github" FORCE)
+            "${CMAKE_SOURCE_DIR}/.github")
     endif()
 endif()


### PR DESCRIPTION
Problem:
- Dependabot config may depend on repo branches. If it already exists in a repo, it should not be force updated.

Solution:
- Don't force-overwrite a dependabot config.