### PR TITLE
:arrow_up: Update Catch2, CPM, Mull, Fuzztest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ env:
   TARGET_LLVM_VERSION: 22
   MULL_LLVM_MAJOR_VERSION: 20
   MULL_LLVM_VERSION: 20.1.2
-  MULL_VERSION: 0.29.0
+  MULL_VERSION: 0.34.0
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Where `abc123` is the version of this repository you want to depend on.
 This repository depends on:
 
 - [Boost-ext.DI](https://github.com/boost-ext/di) at version 1.3.2
-- [Catch2](https://github.com/catchorg/Catch2) at version 3.12.0
-- [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake) at version 0.40.2
-- [fuzztest](https://github.com/google/fuzztest) at git hash d7e0165 (2025-08-05)
+- [Catch2](https://github.com/catchorg/Catch2) at version 3.15.0
+- [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake) at version 0.43.2
+- [fuzztest](https://github.com/google/fuzztest) at version 2026-02-19
 - [GoogleTest](https://github.com/google/googletest) at version 1.16.0
 - [GUnit](https://github.com/cpp-testing/GUnit) at version 1.16.0
 - [metabench](https://github.com/ldionne/metabench) at git hash 3322ce7

--- a/cmake/get_cpm.cmake
+++ b/cmake/get_cpm.cmake
@@ -2,8 +2,8 @@
 #
 # SPDX-FileCopyrightText: Copyright (c) 2019-2023 Lars Melchior and contributors
 
-set(CPM_DOWNLOAD_VERSION 0.42.1)
-set(CPM_HASH_SUM "f3a6dcc6a04ce9e7f51a127307fa4f699fb2bade357a8eb4c5b45df76e1dc6a5")
+set(CPM_DOWNLOAD_VERSION 0.42.3)
+set(CPM_HASH_SUM "a609e875fd532b067174250f6abbc3dac22fe2d64869783fb1e80bda1625c844")
 
 if(CPM_SOURCE_CACHE)
   set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")

--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -22,7 +22,7 @@ target_compile_options(${INFRA_TARGET_NAMESPACE}sanitizer-exceptions
 
 macro(get_catch2)
     if(NOT TARGET Catch2::Catch2WithMain)
-        add_versioned_package("gh:catchorg/Catch2@3.12.0")
+        add_versioned_package("gh:catchorg/Catch2@3.15.0")
         list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras)
         include(Catch)
 
@@ -70,7 +70,7 @@ macro(get_fuzztest)
             NAME
             fuzztest
             GIT_TAG
-            d7e0165
+            "2026-02-19"
             GITHUB_REPOSITORY
             google/fuzztest
             OPTIONS


### PR DESCRIPTION
Problem:
- Some dependencies are out of date.

Solution:
- Update them.