### PR TITLE
:construction_worker: Add info to python project spec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,11 @@ dependencies = [
   "pyyaml",
   "clang-format"
 ]
+license = "BSL-1.0"
+
+[project.urls]
+Repository = "https://github.com/intel/cicd-repo-infrastructure/"
+Documentation = "https://intel.github.io/cicd-repo-infrastructure/"
+
+[tool.setuptools]
+packages = []


### PR DESCRIPTION
Problem:
- This repo currently implements no python modules, so the `pyproject.toml` needs to reflect that.
- General project information is missing from the `pyproject.toml`.

Solution:
- Add empty packages list to `pyproject.toml`.
- Add project information (license, URL, docs) to `pyproject.toml`.