### PR TITLE
:bug: Fix python formatting when formatter is not found

### DIFF
--- a/cmake/black.cmake
+++ b/cmake/black.cmake
@@ -1,8 +1,5 @@
-function(black_format)
-    message(STATUS "black_format(...) is disabled because black was not found.")
-endfunction()
-
 find_program(BLACK_PROGRAM "black")
+
 if(BLACK_PROGRAM)
     message(STATUS "black found at ${BLACK_PROGRAM}")
 else()
@@ -41,3 +38,8 @@ endfunction()
 
 add_black_format_target("check")
 add_black_format_target("fix")
+
+add_dependencies(${INFRA_TARGET_NAMESPACE}quality
+                 ${INFRA_TARGET_NAMESPACE}check-black-format)
+add_dependencies(${INFRA_TARGET_NAMESPACE}ci-quality
+                 ${INFRA_TARGET_NAMESPACE}check-black-format)

--- a/cmake/quality.cmake
+++ b/cmake/quality.cmake
@@ -29,13 +29,5 @@ if(PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     include(${CMAKE_CURRENT_LIST_DIR}/clang-tidy.cmake)
     include(${CMAKE_CURRENT_LIST_DIR}/mypy.cmake)
 
-    include(${CMAKE_CURRENT_LIST_DIR}/black.cmake)
-    include(${CMAKE_CURRENT_LIST_DIR}/ruff.cmake)
-
-    add_dependencies(
-        ${INFRA_TARGET_NAMESPACE}quality
-        ${INFRA_TARGET_NAMESPACE}check-${INFRA_PYTHON_FORMATTER}-format)
-    add_dependencies(
-        ${INFRA_TARGET_NAMESPACE}ci-quality
-        ${INFRA_TARGET_NAMESPACE}check-${INFRA_PYTHON_FORMATTER}-format)
+    include(${CMAKE_CURRENT_LIST_DIR}/${INFRA_PYTHON_FORMATTER}.cmake)
 endif()

--- a/cmake/ruff.cmake
+++ b/cmake/ruff.cmake
@@ -1,8 +1,5 @@
-function(ruff_format)
-    message(STATUS "ruff_format(...) is disabled because ruff was not found.")
-endfunction()
-
 find_program(RUFF_PROGRAM "ruff")
+
 if(RUFF_PROGRAM)
     message(STATUS "ruff found at ${RUFF_PROGRAM}")
 else()
@@ -41,3 +38,8 @@ endfunction()
 
 add_ruff_format_target("check")
 add_ruff_format_target("fix")
+
+add_dependencies(${INFRA_TARGET_NAMESPACE}quality
+                 ${INFRA_TARGET_NAMESPACE}check-ruff-format)
+add_dependencies(${INFRA_TARGET_NAMESPACE}ci-quality
+                 ${INFRA_TARGET_NAMESPACE}check-ruff-format)


### PR DESCRIPTION
Problem:
- When a formatter is not found, python formatting through the CI build fails even though there may be nothing to format.

Solution:
- Preserve backward compatibility and allow python formatting to fail gracefully.